### PR TITLE
Add placement editor and email thumbnail template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# testplugin
+# Woo Laser Photo Mockup
+
+Development repository for the WooCommerce Laser Photo Mockup plugin. See `readme.txt` for WordPress.org style documentation.

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,8 @@
+.llp-variation-fields .llp-media-select{margin-left:5px;}
+.llp-editor-modal{position:fixed;top:0;left:0;width:100%;height:100%;z-index:100000;display:flex;align-items:center;justify-content:center;}
+.llp-editor-backdrop{position:absolute;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.6);}
+.llp-editor-content{position:relative;background:#fff;padding:10px;z-index:100001;max-width:90%;max-height:90%;overflow:auto;}
+.llp-editor-stage{position:relative;display:inline-block;}
+.llp-editor-base{max-width:100%;height:auto;display:block;}
+.llp-rect{position:absolute;border:2px dashed #f00;box-sizing:border-box;cursor:move;}
+.llp-editor-content .llp-editor-close{margin-top:10px;}

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,0 +1,3 @@
+#llp-customizer{margin:1em 0;}
+#llp-customizer button{margin-top:0.5em;}
+#llp-preview img{max-width:100%;height:auto;display:block;margin-top:1em;}

--- a/assets/js/admin-variation.js
+++ b/assets/js/admin-variation.js
@@ -1,0 +1,56 @@
+(function(){
+    document.addEventListener('DOMContentLoaded', function(){
+        document.querySelectorAll('.llp-media-select').forEach(function(btn){
+            btn.addEventListener('click', function(){
+                var frame = wp.media({title:'Select image', multiple:false});
+                frame.on('select', function(){
+                    var attachment = frame.state().get('selection').first().toJSON();
+                    var target = document.getElementById(btn.dataset.target);
+                    if(target){ target.value = attachment.id; }
+                });
+                frame.open();
+            });
+        });
+
+        document.querySelectorAll('.llp-open-editor').forEach(function(btn){
+            btn.addEventListener('click', function(){
+                var loop = btn.dataset.loop;
+                var baseField = document.getElementById('llp_base_image_id_'+loop);
+                if(!baseField || !baseField.value){ alert('Select base image first'); return; }
+                var url = wp.media.attachment(baseField.value).get('url');
+                var bounds = {
+                    x: parseInt(document.getElementById('llp_bounds_x_'+loop).value || 0,10),
+                    y: parseInt(document.getElementById('llp_bounds_y_'+loop).value || 0,10),
+                    w: parseInt(document.getElementById('llp_bounds_w_'+loop).value || 100,10),
+                    h: parseInt(document.getElementById('llp_bounds_h_'+loop).value || 100,10)
+                };
+                var modal = document.createElement('div');
+                modal.className = 'llp-editor-modal';
+                modal.innerHTML = '<div class="llp-editor-backdrop"></div><div class="llp-editor-content"><div class="llp-editor-stage"><img src="'+url+'" class="llp-editor-base"/><div class="llp-rect" style="left:'+bounds.x+'px;top:'+bounds.y+'px;width:'+bounds.w+'px;height:'+bounds.h+'px;"></div></div><p><button type="button" class="button llp-editor-close">'+llpAdmin.closeText+'</button></p></div>';
+                document.body.appendChild(modal);
+                var rect = modal.querySelector('.llp-rect');
+                var stage = modal.querySelector('.llp-editor-stage');
+                var dragging=false, offsetX=0, offsetY=0;
+                rect.addEventListener('mousedown', function(e){ dragging=true; offsetX=e.offsetX; offsetY=e.offsetY; });
+                document.addEventListener('mouseup', function(){ dragging=false; });
+                document.addEventListener('mousemove', function(e){
+                    if(!dragging) return;
+                    var rectStage = stage.getBoundingClientRect();
+                    var x = e.pageX - rectStage.left - offsetX;
+                    var y = e.pageY - rectStage.top - offsetY;
+                    rect.style.left = x + 'px';
+                    rect.style.top = y + 'px';
+                    document.getElementById('llp_bounds_x_'+loop).value = Math.round(x);
+                    document.getElementById('llp_bounds_y_'+loop).value = Math.round(y);
+                });
+                rect.addEventListener('dblclick', function(){
+                    var w = parseInt(prompt(llpAdmin.widthText, rect.offsetWidth),10);
+                    var h = parseInt(prompt(llpAdmin.heightText, rect.offsetHeight),10);
+                    if(w){ rect.style.width=w+'px'; document.getElementById('llp_bounds_w_'+loop).value=w; }
+                    if(h){ rect.style.height=h+'px'; document.getElementById('llp_bounds_h_'+loop).value=h; }
+                });
+                modal.querySelector('.llp-editor-close').addEventListener('click', function(){ modal.remove(); });
+            });
+        });
+    });
+})();

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,0 +1,42 @@
+(function(){
+    const cfg = window.llp_frontend || {};
+    document.addEventListener('DOMContentLoaded', () => {
+        const btn = document.getElementById('llp-upload-btn');
+        const file = document.getElementById('llp-upload');
+        const assetField = document.getElementById('llp_asset_id');
+        const transformField = document.getElementById('llp_transform');
+        const preview = document.getElementById('llp-preview');
+        const addBtn = document.querySelector('form.cart button[type="submit"]');
+        if (addBtn) { addBtn.disabled = true; }
+        if (!btn || !file) return;
+        btn.addEventListener('click', () => {
+            if (!file.files.length) return;
+            const data = new FormData();
+            data.append('file', file.files[0]);
+            const variationInput = document.querySelector('input[name="variation_id"]');
+            data.append('variation_id', variationInput ? variationInput.value : 0);
+            data.append('nonce', cfg.nonce);
+            fetch(cfg.upload_url, {method:'POST', credentials:'same-origin', body:data})
+                .then(r => r.json())
+                .then(res => {
+                    if (!res.asset_id) return;
+                    assetField.value = res.asset_id;
+                    const transform = {scale:1, rotation:0, tx:0, ty:0, crop:{x:0,y:0,w:res.width,h:res.height}};
+                    transformField.value = JSON.stringify(transform);
+                    return fetch(cfg.finalize_url, {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        headers: {'Content-Type':'application/json'},
+                        body: JSON.stringify({nonce:cfg.nonce, asset_id:res.asset_id, variation_id: variationInput ? variationInput.value : 0, transform: transformField.value})
+                    });
+                })
+                .then(r => r ? r.json() : null)
+                .then(res => {
+                    if (res && res.thumb_url) {
+                        preview.innerHTML = '<img src="' + res.thumb_url + '" style="max-width:150px" />';
+                        if (addBtn) { addBtn.disabled = false; }
+                    }
+                });
+        });
+    });
+})();

--- a/includes/class-llp-cron.php
+++ b/includes/class-llp-cron.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Scheduled cleanup tasks.
+ *
+ * @package WooLaserPhotoMockup
+ */
+
+namespace LLP;
+
+use LLP\Traits\Singleton;
+
+class Cron {
+    use Singleton;
+
+    private function __construct() {
+        add_action('llp_daily_purge', [$this, 'purge']);
+    }
+
+    public static function activate(): void {
+        if (!wp_next_scheduled('llp_daily_purge')) {
+            wp_schedule_event(time() + DAY_IN_SECONDS, 'daily', 'llp_daily_purge');
+        }
+    }
+
+    public static function deactivate(): void {
+        $timestamp = wp_next_scheduled('llp_daily_purge');
+        if ($timestamp) {
+            wp_unschedule_event($timestamp, 'llp_daily_purge');
+        }
+    }
+
+    /**
+     * Purge assets older than configured days.
+     */
+    public function purge(): void {
+        $days = (int) Settings::instance()->get('auto_purge_days');
+        if ($days <= 0) {
+            return;
+        }
+        $cutoff = time() - DAY_IN_SECONDS * $days;
+        $dir = Storage::instance()->base_dir();
+        foreach (glob($dir . '*/', GLOB_ONLYDIR) as $asset_dir) {
+            if (filemtime($asset_dir) < $cutoff) {
+                foreach (glob($asset_dir . '*') as $file) {
+                    @unlink($file);
+                }
+                @rmdir($asset_dir);
+            }
+        }
+    }
+}

--- a/includes/class-llp-order.php
+++ b/includes/class-llp-order.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Order integration and persistence.
+ *
+ * @package WooLaserPhotoMockup
+ */
+
+namespace LLP;
+
+use LLP\Traits\Singleton;
+
+class Order {
+    use Singleton;
+
+    private function __construct() {
+        add_action('woocommerce_checkout_create_order_line_item', [$this, 'persist_order_item_meta'], 10, 4);
+        add_action('woocommerce_email_after_order_table', [$this, 'email_thumbs'], 10, 4);
+        add_action('add_meta_boxes', [$this, 'meta_box']);
+        add_action('admin_post_llp_purge_order', [$this, 'handle_purge']);
+    }
+
+    /**
+     * Persist order item meta on checkout.
+     */
+    public function persist_order_item_meta($item, string $cart_item_key, array $values, $order_id): void {
+        $keys = ['_llp_asset_id', '_llp_transform', '_llp_original_url', '_llp_composite_url', '_llp_thumb_url'];
+        foreach ($keys as $key) {
+            if (isset($values[$key])) {
+                $item->add_meta_data($key, $values[$key], true);
+            }
+        }
+    }
+
+    /**
+     * Output thumbnails in emails.
+     */
+    public function email_thumbs($order, $sent_to_admin, $plain_text, $email): void {
+        if ($plain_text) {
+            return;
+        }
+        foreach ($order->get_items() as $item) {
+            $asset_id = $item->get_meta('_llp_asset_id');
+            if ($asset_id) {
+                $thumb = Security::instance()->sign_url($asset_id, 'thumb.jpg');
+                wc_get_template('emails/line-item-preview.php', ['thumb_url' => $thumb], '', LLP_DIR . 'templates/');
+            }
+        }
+    }
+
+    /**
+     * Add order meta box for asset preview and purge.
+     */
+    public function meta_box(): void {
+        add_meta_box('llp_assets', __('Laser Photo Assets', 'llp'), [$this, 'render_meta_box'], 'shop_order', 'side');
+    }
+
+    /**
+     * Render the order meta box.
+     */
+    public function render_meta_box($post): void {
+        $order = wc_get_order($post->ID);
+        if (!$order) {
+            return;
+        }
+        foreach ($order->get_items() as $item) {
+            $asset_id = $item->get_meta('_llp_asset_id');
+            if ($asset_id) {
+                $thumb = Security::instance()->sign_url($asset_id, 'thumb.jpg');
+                echo '<p><img src="' . esc_url($thumb) . '" style="max-width:100%;" /></p>';
+            }
+        }
+        $url = wp_nonce_url(admin_url('admin-post.php?action=llp_purge_order&order_id=' . $post->ID), 'llp_purge_order');
+        echo '<p><a class="button" href="' . esc_url($url) . '">' . esc_html__('Delete customer assets', 'llp') . '</a></p>';
+    }
+
+    /**
+     * Handle purge request from order screen.
+     */
+    public function handle_purge(): void {
+        if (!current_user_can('edit_shop_orders')) {
+            wp_die(__('Permission denied', 'llp'));
+        }
+        $order_id = absint($_GET['order_id'] ?? 0);
+        if (!$order_id || !wp_verify_nonce($_GET['_wpnonce'] ?? '', 'llp_purge_order')) {
+            wp_die(__('Invalid request', 'llp'));
+        }
+        $order = wc_get_order($order_id);
+        if ($order) {
+            foreach ($order->get_items() as $item) {
+                $asset_id = $item->get_meta('_llp_asset_id');
+                if ($asset_id) {
+                    Storage::instance()->delete($asset_id);
+                }
+            }
+        }
+        wp_safe_redirect(wp_get_referer() ?: admin_url('post.php?post=' . $order_id . '&action=edit'));
+        exit;
+    }
+}

--- a/includes/class-llp-plugin.php
+++ b/includes/class-llp-plugin.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Core plugin bootstrap.
+ *
+ * @package WooLaserPhotoMockup
+ */
+
+namespace LLP;
+
+use LLP\Traits\Singleton;
+
+class Plugin {
+    use Singleton;
+
+    /**
+     * Boot plugin services.
+     */
+    public function boot(): void {
+        // Register hooks or instantiate core classes.
+        Settings::instance();
+        Frontend::instance();
+        Variation_Fields::instance();
+        Order::instance();
+        REST::instance();
+        Cron::instance();
+        Renderer::instance();
+        Storage::instance();
+        Security::instance();
+    }
+}

--- a/includes/class-llp-renderer.php
+++ b/includes/class-llp-renderer.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Image rendering utilities.
+ *
+ * @package WooLaserPhotoMockup
+ */
+
+namespace LLP;
+
+use LLP\Traits\Singleton;
+
+class Renderer {
+    use Singleton;
+
+    /**
+     * Render composite image based on settings.
+     *
+     * @param array $args Rendering arguments.
+     */
+    public function render(array $args): bool {
+        $base_path    = $args['base_path'];
+        $mask_path    = $args['mask_path'] ?? null;
+        $user_path    = $args['user_img'];
+        $bounds       = $args['bounds'];
+        $transform    = $args['transform'];
+        $output_dpi   = $args['output_dpi'] ?? 300;
+        $composite_out= $args['out_composite'];
+        $thumb_out    = $args['out_thumb'];
+
+        if (class_exists('Imagick')) {
+            try {
+                $base = new \Imagick($base_path);
+                $user = new \Imagick($user_path);
+                $base->setImageUnits(\Imagick::RESOLUTION_PIXELSPERINCH);
+                $base->setImageResolution($output_dpi, $output_dpi);
+
+                $user->autoOrient();
+                $user->setImageAlphaChannel(\Imagick::ALPHACHANNEL_SET);
+                $user->stripImage();
+
+                if (!empty($transform['crop'])) {
+                    $user->cropImage($transform['crop']['w'], $transform['crop']['h'], $transform['crop']['x'], $transform['crop']['y']);
+                }
+
+                $user->resizeImage($bounds['w'] * $transform['scale'], $bounds['h'] * $transform['scale'], \Imagick::FILTER_LANCZOS, 1);
+                $user->rotateImage(new \ImagickPixel('transparent'), $transform['rotation']);
+
+                $canvas = $base->clone();
+
+                $px = $bounds['x'] + ($transform['tx'] ?? 0);
+                $py = $bounds['y'] + ($transform['ty'] ?? 0);
+
+                if ($mask_path) {
+                    $layer = new \Imagick();
+                    $layer->newImage($base->getImageWidth(), $base->getImageHeight(), new \ImagickPixel('transparent'), 'png');
+                    $layer->compositeImage($user, \Imagick::COMPOSITE_DEFAULT, $px, $py);
+                    $mask = new \Imagick($mask_path);
+                    $layer->compositeImage($mask, \Imagick::COMPOSITE_DSTIN, 0, 0);
+                    $canvas->compositeImage($layer, \Imagick::COMPOSITE_DEFAULT, 0, 0);
+                } else {
+                    $canvas->compositeImage($user, \Imagick::COMPOSITE_DEFAULT, $px, $py);
+                }
+
+                $canvas->setImageFormat('png');
+                $canvas->writeImage($composite_out);
+
+                $thumb = $canvas->clone();
+                $thumb->thumbnailImage(800, 0);
+                $thumb->setImageFormat('jpeg');
+                $thumb->writeImage($thumb_out);
+                return true;
+            } catch (\Exception $e) {
+                return false;
+            }
+        }
+
+        // GD fallback (very basic)
+        $base = imagecreatefromstring(file_get_contents($base_path));
+        $user = imagecreatefromstring(file_get_contents($user_path));
+        if (!$base || !$user) {
+            return false;
+        }
+        $canvas = $base;
+        $scaled_w = (int) ($bounds['w'] * $transform['scale']);
+        $scaled_h = (int) ($bounds['h'] * $transform['scale']);
+        $tmp = imagecreatetruecolor($scaled_w, $scaled_h);
+        imagealphablending($tmp, false);
+        imagesavealpha($tmp, true);
+        imagecopyresampled($tmp, $user, 0, 0, $transform['crop']['x'] ?? 0, $transform['crop']['y'] ?? 0, $scaled_w, $scaled_h, $transform['crop']['w'] ?? imagesx($user), $transform['crop']['h'] ?? imagesy($user));
+        if (!empty($transform['rotation'])) {
+            $tmp = imagerotate($tmp, -$transform['rotation'], 0);
+        }
+        $px = $bounds['x'] + ($transform['tx'] ?? 0);
+        $py = $bounds['y'] + ($transform['ty'] ?? 0);
+        imagecopy($canvas, $tmp, $px, $py, 0, 0, imagesx($tmp), imagesy($tmp));
+        imagepng($canvas, $composite_out);
+        $thumb = imagescale($canvas, 800);
+        imagejpeg($thumb, $thumb_out, 90);
+        imagedestroy($tmp);
+        imagedestroy($thumb);
+        imagedestroy($user);
+        imagedestroy($base);
+        return true;
+    }
+}

--- a/includes/class-llp-rest.php
+++ b/includes/class-llp-rest.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * REST API endpoints.
+ *
+ * @package WooLaserPhotoMockup
+ */
+
+namespace LLP;
+
+use LLP\Traits\Singleton;
+
+class REST {
+    use Singleton;
+
+    private function __construct() {
+        add_action('rest_api_init', [$this, 'register_routes']);
+    }
+
+    public function register_routes(): void {
+        register_rest_route('llp/v1', '/upload', [
+            'methods'             => 'POST',
+            'callback'            => [$this, 'handle_upload'],
+            'permission_callback' => '__return_true',
+        ]);
+
+        register_rest_route('llp/v1', '/finalize', [
+            'methods'             => 'POST',
+            'callback'            => [$this, 'handle_finalize'],
+            'permission_callback' => '__return_true',
+        ]);
+
+        register_rest_route('llp/v1', '/file/(?P<asset_id>[a-f0-9\-]+)/(?P<file>[\w\.]+)', [
+            'methods'             => 'GET',
+            'callback'            => [$this, 'serve_file'],
+            'permission_callback' => '__return_true',
+            'args'                => [
+                'asset_id' => ['sanitize_callback' => 'sanitize_text_field'],
+                'file'     => ['sanitize_callback' => 'sanitize_file_name'],
+            ],
+        ]);
+
+        register_rest_route('llp/v1', '/order/(?P<order_id>\d+)/purge', [
+            'methods'             => 'POST',
+            'callback'            => [$this, 'purge_order'],
+            'permission_callback' => function () {
+                return current_user_can('edit_shop_orders');
+            },
+            'args' => [
+                'order_id' => ['sanitize_callback' => 'absint'],
+            ],
+        ]);
+    }
+
+    /**
+     * Handle file upload to temp storage.
+     */
+    public function handle_upload(\WP_REST_Request $request) {
+        if (!wp_verify_nonce($request->get_param('nonce'), 'llp')) {
+            return new \WP_Error('invalid_nonce', __('Invalid nonce', 'llp'), ['status' => 403]);
+        }
+        $variation_id = absint($request->get_param('variation_id'));
+        $files = $request->get_file_params();
+        if (empty($files['file'])) {
+            return new \WP_Error('no_file', __('No file provided', 'llp'), ['status' => 400]);
+        }
+        $asset_id = wp_generate_uuid4();
+        $dir      = Storage::instance()->temp_dir($asset_id);
+        $dest     = $dir . 'original.png';
+        $sec      = Security::instance();
+        $info     = $sec->process_upload($files['file'], $dest, $variation_id);
+        if (is_wp_error($info)) {
+            return $info;
+        }
+        return rest_ensure_response([
+            'asset_id' => $asset_id,
+            'width'    => $info['width'],
+            'height'   => $info['height'],
+        ]);
+    }
+
+    /**
+     * Finalize upload and render composites.
+     */
+    public function handle_finalize(\WP_REST_Request $request) {
+        if (!wp_verify_nonce($request->get_param('nonce'), 'llp')) {
+            return new \WP_Error('invalid_nonce', __('Invalid nonce', 'llp'), ['status' => 403]);
+        }
+        $asset_id    = sanitize_text_field($request->get_param('asset_id'));
+        $variation_id = absint($request->get_param('variation_id'));
+        $transform   = json_decode($request->get_param('transform', ''), true);
+
+        if (!$asset_id || !$variation_id || empty($transform)) {
+            return new \WP_Error('missing_data', __('Missing data', 'llp'), ['status' => 400]);
+        }
+
+        $storage   = Storage::instance();
+        $tmp_dir   = $storage->temp_dir($asset_id);
+        $final_dir = $storage->asset_dir($asset_id);
+        @rename($tmp_dir . 'original.png', $final_dir . 'original.png');
+
+        $base_id = (int) get_post_meta($variation_id, '_llp_base_image_id', true);
+        $mask_id = (int) get_post_meta($variation_id, '_llp_mask_image_id', true);
+        $base_path = get_attached_file($base_id);
+        $mask_path = $mask_id ? get_attached_file($mask_id) : null;
+        $bounds    = json_decode((string) get_post_meta($variation_id, '_llp_bounds', true), true) ?: [];
+        $dpi       = (int) get_post_meta($variation_id, '_llp_output_dpi', true) ?: 300;
+
+        $renderer = Renderer::instance();
+        $renderer->render([
+            'base_path'    => $base_path,
+            'mask_path'    => $mask_path,
+            'user_img'     => $final_dir . 'original.png',
+            'bounds'       => $bounds,
+            'transform'    => $transform,
+            'output_dpi'   => $dpi,
+            'out_composite'=> $final_dir . 'composite.png',
+            'out_thumb'    => $final_dir . 'thumb.jpg',
+        ]);
+
+        $sec = Security::instance();
+        return rest_ensure_response([
+            'asset_id'      => $asset_id,
+            'original_url'  => $sec->sign_url($asset_id, 'original.png'),
+            'composite_url' => $sec->sign_url($asset_id, 'composite.png'),
+            'thumb_url'     => $sec->sign_url($asset_id, 'thumb.jpg'),
+        ]);
+    }
+
+    /**
+     * Serve a protected file if token is valid.
+     */
+    public function serve_file(\WP_REST_Request $request) {
+        $asset_id = $request['asset_id'];
+        $file     = $request['file'];
+        $token    = $request->get_param('token');
+        $expires  = (int) $request->get_param('expires');
+        $sec      = Security::instance();
+        if (!$token || !$sec->verify($asset_id, $file, $expires, $token)) {
+            return new \WP_Error('forbidden', __('Invalid token.', 'llp'), ['status' => 403]);
+        }
+        $path = Storage::instance()->asset_dir($asset_id) . $file;
+        if (!file_exists($path)) {
+            return new \WP_Error('not_found', __('File not found', 'llp'), ['status' => 404]);
+        }
+        $mime = wp_check_filetype($path); 
+        $data = file_get_contents($path);
+        return new \WP_REST_Response($data, 200, ['Content-Type' => $mime['type'] ?: 'application/octet-stream']);
+    }
+
+    /**
+     * Purge assets for an order.
+     */
+    public function purge_order(\WP_REST_Request $request) {
+        if (!wp_verify_nonce($request->get_param('nonce'), 'llp')) {
+            return new \WP_Error('invalid_nonce', __('Invalid nonce', 'llp'), ['status' => 403]);
+        }
+        $order_id = (int) $request['order_id'];
+        $order    = wc_get_order($order_id);
+        if (!$order) {
+            return new \WP_Error('not_found', __('Order not found', 'llp'), ['status' => 404]);
+        }
+        foreach ($order->get_items() as $item) {
+            $asset_id = $item->get_meta('_llp_asset_id');
+            if ($asset_id) {
+                Storage::instance()->delete($asset_id);
+            }
+        }
+        return rest_ensure_response(['purged' => true]);
+    }
+}

--- a/includes/class-llp-security.php
+++ b/includes/class-llp-security.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Security helpers.
+ *
+ * @package WooLaserPhotoMockup
+ */
+
+namespace LLP;
+
+use LLP\Traits\Singleton;
+
+class Security {
+    use Singleton;
+
+    /**
+     * Generate a nonce field for forms.
+     */
+    public function nonce_field(): void {
+        wp_nonce_field('llp', '_llp_nonce');
+    }
+
+    /**
+     * Validate and move uploaded file.
+     *
+     * @return array|\WP_Error { width, height, sha256 }
+     */
+    public function process_upload(array $file, string $dest, int $variation_id) {
+        $settings = Settings::instance();
+        $allowed  = $settings->get('allowed_mimes');
+        $max_size = (int) $settings->get('max_file_size');
+        if ($file['error'] || $file['size'] > $max_size) {
+            return new \WP_Error('upload_error', __('Upload failed.', 'llp'));
+        }
+        $type = wp_check_filetype_and_ext($file['tmp_name'], $file['name']);
+        if (!$type['type'] || !in_array($type['type'], $allowed, true)) {
+            return new \WP_Error('invalid_type', __('Invalid file type.', 'llp'));
+        }
+        $editor = wp_get_image_editor($file['tmp_name']);
+        if (is_wp_error($editor)) {
+            return $editor;
+        }
+        $editor->set_quality(100);
+        $saved = $editor->save($dest, 'image/png');
+        if (is_wp_error($saved)) {
+            return $saved;
+        }
+        $size = getimagesize($dest);
+        $hash = hash_file('sha256', $dest);
+        return ['width' => $size[0], 'height' => $size[1], 'sha256' => $hash];
+    }
+
+    /**
+     * Generate a signed URL for downloading an asset.
+     */
+    public function sign_url(string $asset_id, string $file, int $expires = 0): string {
+        $expires = $expires ?: time() + DAY_IN_SECONDS;
+        $secret  = wp_salt('llp');
+        $token   = hash_hmac('sha256', $asset_id . '|' . $file . '|' . $expires, $secret);
+        $base    = rest_url(sprintf('llp/v1/file/%s/%s', $asset_id, $file));
+        return add_query_arg([
+            'token'   => $token,
+            'expires' => $expires,
+        ], $base);
+    }
+
+    /**
+     * Verify a signed URL token.
+     */
+    public function verify(string $asset_id, string $file, int $expires, string $token): bool {
+        if ($expires < time()) {
+            return false;
+        }
+        $secret  = wp_salt('llp');
+        $expected = hash_hmac('sha256', $asset_id . '|' . $file . '|' . $expires, $secret);
+        return hash_equals($expected, $token);
+    }
+}

--- a/includes/class-llp-settings.php
+++ b/includes/class-llp-settings.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Plugin settings handler.
+ *
+ * @package WooLaserPhotoMockup
+ */
+
+namespace LLP;
+
+use LLP\Traits\Singleton;
+
+class Settings {
+    use Singleton;
+
+    /**
+     * Default settings.
+     *
+     * @var array
+     */
+    private array $defaults = [
+        'max_file_size'   => 15 * 1024 * 1024,
+        'allowed_mimes'   => ['image/jpeg', 'image/png', 'image/webp'],
+        'storage'         => 'private',
+        'auto_purge_days' => 0,
+    ];
+
+    private function __construct() {
+        add_action('admin_init', [$this, 'register']);
+        add_action('admin_menu', [$this, 'menu']);
+    }
+
+    /**
+     * Register setting.
+     */
+    public function register(): void {
+        register_setting('llp_settings', 'llp_settings', [$this, 'sanitize']);
+    }
+
+    /**
+     * Add menu page under WooCommerce.
+     */
+    public function menu(): void {
+        add_submenu_page(
+            'woocommerce',
+            __('Laser Photo Mockup', 'llp'),
+            __('Laser Photo Mockup', 'llp'),
+            'manage_woocommerce',
+            'llp-settings',
+            [$this, 'render_page']
+        );
+    }
+
+    /**
+     * Render settings page.
+     */
+    public function render_page(): void {
+        $opts = $this->get();
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('Laser Photo Mockup Settings', 'llp'); ?></h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields('llp_settings');
+                ?>
+                <table class="form-table" role="presentation">
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Max file size (bytes)', 'llp'); ?></th>
+                        <td><input type="number" name="llp_settings[max_file_size]" value="<?php echo esc_attr($opts['max_file_size']); ?>" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Allowed MIME types', 'llp'); ?></th>
+                        <td><input type="text" name="llp_settings[allowed_mimes]" value="<?php echo esc_attr(implode(',', $opts['allowed_mimes'])); ?>" class="regular-text" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Storage mode', 'llp'); ?></th>
+                        <td>
+                            <select name="llp_settings[storage]">
+                                <option value="private" <?php selected($opts['storage'], 'private'); ?>><?php esc_html_e('Private', 'llp'); ?></option>
+                                <option value="public" <?php selected($opts['storage'], 'public'); ?>><?php esc_html_e('Public', 'llp'); ?></option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Auto purge days', 'llp'); ?></th>
+                        <td><input type="number" name="llp_settings[auto_purge_days]" value="<?php echo esc_attr($opts['auto_purge_days']); ?>" /></td>
+                    </tr>
+                </table>
+                <?php submit_button(); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Sanitize settings input.
+     */
+    public function sanitize(array $input): array {
+        $clean = [
+            'max_file_size'   => absint($input['max_file_size'] ?? $this->defaults['max_file_size']),
+            'allowed_mimes'   => array_filter(array_map('sanitize_text_field', explode(',', $input['allowed_mimes'] ?? ''))),
+            'storage'         => in_array($input['storage'] ?? 'private', ['private', 'public'], true) ? $input['storage'] : 'private',
+            'auto_purge_days' => absint($input['auto_purge_days'] ?? 0),
+        ];
+        return $clean;
+    }
+
+    /**
+     * Get setting value or all settings.
+     */
+    public function get(?string $key = null) {
+        $opts = wp_parse_args(get_option('llp_settings', []), $this->defaults);
+        if ($key) {
+            return $opts[$key] ?? null;
+        }
+        return $opts;
+    }
+}

--- a/includes/class-llp-storage.php
+++ b/includes/class-llp-storage.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * File storage handler.
+ *
+ * @package WooLaserPhotoMockup
+ */
+
+namespace LLP;
+
+use LLP\Traits\Singleton;
+
+class Storage {
+    use Singleton;
+
+    /**
+     * Ensure directory exists.
+     */
+    private function ensure(string $path): void {
+        if (!file_exists($path)) {
+            wp_mkdir_p($path);
+        }
+    }
+
+    /**
+     * Base directory for assets.
+     */
+    public function base_dir(): string {
+        $dir = LLP_UPLOAD_DIR;
+        $this->ensure($dir);
+        return $dir;
+    }
+
+    /**
+     * Base URL for assets.
+     */
+    public function base_url(): string {
+        return LLP_UPLOAD_URL;
+    }
+
+    /**
+     * Temporary directory for upload.
+     */
+    public function temp_dir(string $asset_id): string {
+        $dir = trailingslashit($this->base_dir() . 'tmp/' . $asset_id);
+        $this->ensure($dir);
+        return $dir;
+    }
+
+    /**
+     * Final asset directory.
+     */
+    public function asset_dir(string $asset_id): string {
+        $dir = trailingslashit($this->base_dir() . $asset_id);
+        $this->ensure($dir);
+        return $dir;
+    }
+
+    /**
+     * Asset URL.
+     */
+    public function asset_url(string $asset_id, string $file): string {
+        return trailingslashit($this->base_url()) . $asset_id . '/' . $file;
+    }
+
+    /**
+     * Delete all files for an asset.
+     */
+    public function delete(string $asset_id): void {
+        $dir = trailingslashit($this->base_dir() . $asset_id);
+        if (!file_exists($dir)) {
+            return;
+        }
+        foreach (glob($dir . '*') as $file) {
+            @unlink($file);
+        }
+        @rmdir($dir);
+    }
+}

--- a/includes/class-llp-variation-fields.php
+++ b/includes/class-llp-variation-fields.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Variation fields for mockup configuration.
+ *
+ * @package WooLaserPhotoMockup
+ */
+
+namespace LLP;
+
+use LLP\Traits\Singleton;
+
+class Variation_Fields {
+    use Singleton;
+
+    private function __construct() {
+        add_action('woocommerce_product_after_variable_attributes', [$this, 'render'], 10, 3);
+        add_action('woocommerce_save_product_variation', [$this, 'save'], 10, 2);
+        add_action('admin_enqueue_scripts', [$this, 'scripts']);
+    }
+
+    /**
+     * Enqueue admin assets.
+     */
+    public function scripts($hook): void {
+        if (!function_exists('get_current_screen')) {
+            return;
+        }
+        $screen = get_current_screen();
+        if (!$screen || 'product' !== $screen->id) {
+            return;
+        }
+        wp_enqueue_media();
+        wp_enqueue_script('llp-admin-variation', LLP_URL . 'assets/js/admin-variation.js', [], LLP_VER, true);
+        wp_localize_script('llp-admin-variation', 'llpAdmin', [
+            'closeText'  => __('Close', 'llp'),
+            'widthText'  => __('Width (px)', 'llp'),
+            'heightText' => __('Height (px)', 'llp'),
+        ]);
+        wp_enqueue_style('llp-admin', LLP_URL . 'assets/css/admin.css', [], LLP_VER);
+    }
+
+    /**
+     * Render fields in variation edit screen.
+     */
+    public function render(int $loop, array $variation_data, $variation): void {
+        $base  = get_post_meta($variation->ID, '_llp_base_image_id', true);
+        $mask  = get_post_meta($variation->ID, '_llp_mask_image_id', true);
+        $bounds = json_decode((string) get_post_meta($variation->ID, '_llp_bounds', true), true) ?: [];
+        $aspect = get_post_meta($variation->ID, '_llp_aspect_ratio', true);
+        $minres = json_decode((string) get_post_meta($variation->ID, '_llp_min_resolution', true), true) ?: [];
+        $dpi    = get_post_meta($variation->ID, '_llp_output_dpi', true);
+
+        echo '<div class="llp-variation-fields">';
+        echo '<p class="form-field"><label for="llp_base_image_id_' . $loop . '">' . esc_html__('Base image ID', 'llp') . '</label>';
+        echo '<input type="text" class="short" id="llp_base_image_id_' . $loop . '" name="llp_base_image_id[' . $loop . ']" value="' . esc_attr($base) . '" /> ';
+        echo '<button type="button" class="button llp-media-select" data-target="llp_base_image_id_' . $loop . '">' . esc_html__('Select', 'llp') . '</button></p>';
+
+        echo '<p class="form-field"><label for="llp_mask_image_id_' . $loop . '">' . esc_html__('Mask image ID', 'llp') . '</label>';
+        echo '<input type="text" class="short" id="llp_mask_image_id_' . $loop . '" name="llp_mask_image_id[' . $loop . ']" value="' . esc_attr($mask) . '" /> ';
+        echo '<button type="button" class="button llp-media-select" data-target="llp_mask_image_id_' . $loop . '">' . esc_html__('Select', 'llp') . '</button></p>';
+
+        woocommerce_wp_text_input([
+            'id'          => "llp_bounds_x_{$loop}",
+            'name'        => "llp_bounds_x[{$loop}]",
+            'label'       => __('Bounds X', 'llp'),
+            'value'       => $bounds['x'] ?? '',
+            'type'        => 'number',
+        ]);
+        woocommerce_wp_text_input([
+            'id'          => "llp_bounds_y_{$loop}",
+            'name'        => "llp_bounds_y[{$loop}]",
+            'label'       => __('Bounds Y', 'llp'),
+            'value'       => $bounds['y'] ?? '',
+            'type'        => 'number',
+        ]);
+        woocommerce_wp_text_input([
+            'id'          => "llp_bounds_w_{$loop}",
+            'name'        => "llp_bounds_w[{$loop}]",
+            'label'       => __('Bounds Width', 'llp'),
+            'value'       => $bounds['w'] ?? '',
+            'type'        => 'number',
+        ]);
+        woocommerce_wp_text_input([
+            'id'          => "llp_bounds_h_{$loop}",
+            'name'        => "llp_bounds_h[{$loop}]",
+            'label'       => __('Bounds Height', 'llp'),
+            'value'       => $bounds['h'] ?? '',
+            'type'        => 'number',
+        ]);
+        woocommerce_wp_text_input([
+            'id'          => "llp_bounds_rotation_{$loop}",
+            'name'        => "llp_bounds_rotation[{$loop}]",
+            'label'       => __('Bounds Rotation', 'llp'),
+            'value'       => $bounds['rotation'] ?? '',
+            'type'        => 'number',
+            'custom_attributes' => ['step' => 'any'],
+        ]);
+
+        echo '<p class="form-field"><button type="button" class="button llp-open-editor" data-loop="' . $loop . '">' . esc_html__('Open Placement Editor', 'llp') . '</button></p>';
+
+        woocommerce_wp_text_input([
+            'id'          => "llp_aspect_ratio_{$loop}",
+            'name'        => "llp_aspect_ratio[{$loop}]",
+            'label'       => __('Aspect ratio (W:H)', 'llp'),
+            'value'       => $aspect,
+        ]);
+        woocommerce_wp_text_input([
+            'id'          => "llp_min_res_w_{$loop}",
+            'name'        => "llp_min_res_w[{$loop}]",
+            'label'       => __('Min width (px)', 'llp'),
+            'value'       => $minres['min_w'] ?? '',
+            'type'        => 'number',
+        ]);
+        woocommerce_wp_text_input([
+            'id'          => "llp_min_res_h_{$loop}",
+            'name'        => "llp_min_res_h[{$loop}]",
+            'label'       => __('Min height (px)', 'llp'),
+            'value'       => $minres['min_h'] ?? '',
+            'type'        => 'number',
+        ]);
+        woocommerce_wp_text_input([
+            'id'          => "llp_output_dpi_{$loop}",
+            'name'        => "llp_output_dpi[{$loop}]",
+            'label'       => __('Output DPI', 'llp'),
+            'value'       => $dpi,
+            'type'        => 'number',
+        ]);
+        echo '</div>';
+    }
+
+    /**
+     * Save variation meta.
+     */
+    public function save(int $variation_id, int $i): void {
+        $base = absint($_POST['llp_base_image_id'][$i] ?? 0);
+        update_post_meta($variation_id, '_llp_base_image_id', $base);
+
+        $mask = absint($_POST['llp_mask_image_id'][$i] ?? 0);
+        update_post_meta($variation_id, '_llp_mask_image_id', $mask);
+
+        $bounds = [
+            'x'        => absint($_POST['llp_bounds_x'][$i] ?? 0),
+            'y'        => absint($_POST['llp_bounds_y'][$i] ?? 0),
+            'w'        => absint($_POST['llp_bounds_w'][$i] ?? 0),
+            'h'        => absint($_POST['llp_bounds_h'][$i] ?? 0),
+            'rotation' => floatval($_POST['llp_bounds_rotation'][$i] ?? 0),
+        ];
+        update_post_meta($variation_id, '_llp_bounds', wp_json_encode($bounds));
+
+        $aspect = sanitize_text_field($_POST['llp_aspect_ratio'][$i] ?? '');
+        update_post_meta($variation_id, '_llp_aspect_ratio', $aspect);
+
+        $minres = [
+            'min_w' => absint($_POST['llp_min_res_w'][$i] ?? 0),
+            'min_h' => absint($_POST['llp_min_res_h'][$i] ?? 0),
+        ];
+        update_post_meta($variation_id, '_llp_min_resolution', wp_json_encode($minres));
+
+        $dpi = absint($_POST['llp_output_dpi'][$i] ?? 300);
+        update_post_meta($variation_id, '_llp_output_dpi', $dpi);
+    }
+}

--- a/languages/llp-en_US.po
+++ b/languages/llp-en_US.po
@@ -1,0 +1,17 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Woo Laser Photo Mockup 1.0.0\n"
+"POT-Creation-Date: 2024-01-01 00:00+0000\n"
+"PO-Revision-Date: 2024-01-01 00:00+0000\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: templates/single-product/customizer.php:11
+msgid "Image customizer placeholder."
+msgstr "Image customizer placeholder."
+
+#: templates/emails/line-item-preview.php:11
+msgid "Thumbnail preview placeholder."
+msgstr "Thumbnail preview placeholder."

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,26 @@
+=== Woo Laser Photo Mockup ===
+Contributors: example
+Tags: woocommerce, upload, mockup
+Requires at least: 6.0
+Tested up to: 6.5
+Requires PHP: 8.1
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+A WooCommerce extension that lets customers upload and position photos into predefined laser mockups.
+
+== Description ==
+
+This plugin allows variable products to define custom placement bounds where customers can upload, crop, and preview images before purchasing. Uploaded files are stored privately and served via signed URLs, and store owners can purge customer assets per order or automatically via cron.
+
+== Installation ==
+
+1. Upload the plugin files to the `/wp-content/plugins/` directory.
+2. Activate the plugin through the 'Plugins' screen in WordPress.
+3. Configure plugin settings under WooCommerce > Settings > Laser Photo Mockup.
+
+== Changelog ==
+
+= 1.0.0 =
+* Initial release.

--- a/templates/emails/line-item-preview.php
+++ b/templates/emails/line-item-preview.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Email thumbnail preview template.
+ *
+ * @package WooLaserPhotoMockup
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$thumb_url = $thumb_url ?? '';
+echo '<div class="llp-email-thumb"><img src="' . esc_url($thumb_url) . '" alt="" style="max-width:120px;" /></div>';

--- a/templates/single-product/customizer.php
+++ b/templates/single-product/customizer.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Customer-facing image customizer.
+ *
+ * @package WooLaserPhotoMockup
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+echo '<div id="llp-customizer">';
+?>
+<input type="file" id="llp-upload" accept="image/*" />
+<input type="hidden" name="_llp_asset_id" id="llp_asset_id" />
+<input type="hidden" name="_llp_transform" id="llp_transform" />
+<button type="button" id="llp-upload-btn"><?php esc_html_e('Upload Photo', 'llp'); ?></button>
+<div id="llp-preview"></div>
+</div>

--- a/traits/trait-singleton.php
+++ b/traits/trait-singleton.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Simple singleton trait.
+ *
+ * @package WooLaserPhotoMockup
+ */
+
+namespace LLP\Traits;
+
+trait Singleton {
+    private static ?self $instance = null;
+
+    final public static function instance(): self {
+        if (null === static::$instance) {
+            static::$instance = new static();
+        }
+        return static::$instance;
+    }
+
+    private function __clone() {}
+    public function __wakeup() {}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Fired when the plugin is uninstalled.
+ *
+ * @package WooLaserPhotoMockup
+ */
+
+declare(strict_types=1);
+
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+    exit;
+}
+
+$uploads = wp_upload_dir(null, false);
+define('LLP_UPLOAD_DIR', trailingslashit($uploads['basedir']) . 'llp/');
+
+$settings = get_option('llp_settings', []);
+delete_option('llp_settings');
+
+if (!empty($settings['delete_on_uninstall'])) {
+    $dir = LLP_UPLOAD_DIR;
+    if (is_dir($dir)) {
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($files as $fileinfo) {
+            $todo = ($fileinfo->isDir() ? 'rmdir' : 'unlink');
+            @$todo($fileinfo->getRealPath());
+        }
+        @rmdir($dir);
+    }
+}

--- a/woo-laser-photo-mockup.php
+++ b/woo-laser-photo-mockup.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Plugin Name: Woo Laser Photo Mockup
+ * Description: Variable product image upload + mockup generator with per-variation placement.
+ * Version: 1.0.0
+ * Requires PHP: 8.1
+ * WC requires at least: 8.0
+ * WC tested up to: 9.0
+ * Text Domain: llp
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+define('LLP_VER', '1.0.0');
+define('LLP_DIR', __DIR__ . '/');
+define('LLP_URL', plugins_url('/', __FILE__));
+// Upload dirs are calculated early so other classes can rely on them.
+$uploads = wp_upload_dir(null, false);
+define('LLP_UPLOAD_DIR', trailingslashit($uploads['basedir']) . 'llp/');
+define('LLP_UPLOAD_URL', trailingslashit($uploads['baseurl']) . 'llp/');
+
+// Simple autoloader for plugin classes and traits.
+spl_autoload_register(static function (string $class): void {
+    if (strpos($class, 'LLP\\') !== 0) {
+        return;
+    }
+    $parts = explode('\\', $class);
+    $leaf  = array_pop($parts);
+    $leaf  = strtolower(str_replace('_', '-', $leaf));
+    if ($parts && 'Traits' === $parts[count($parts) - 1]) {
+        $file = LLP_DIR . 'traits/trait-' . $leaf . '.php';
+    } else {
+        $file = LLP_DIR . 'includes/class-llp-' . $leaf . '.php';
+    }
+    if (file_exists($file)) {
+        require_once $file;
+    }
+});
+
+register_activation_hook(__FILE__, ['\LLP\Cron', 'activate']);
+register_deactivation_hook(__FILE__, ['\LLP\Cron', 'deactivate']);
+
+add_action('plugins_loaded', static function () {
+    if (!class_exists('WooCommerce')) {
+        return;
+    }
+    require_once LLP_DIR . 'includes/class-llp-plugin.php';
+    \LLP\Plugin::instance()->boot();
+});


### PR DESCRIPTION
## Summary
- enable media library and placement editor for variation configuration
- show uploaded image thumbnails in transactional emails
- gate add-to-cart until an upload is finalized on the frontend

## Testing
- `find . -name "*.php" -exec php -l {} \;`


------
https://chatgpt.com/codex/tasks/task_e_68a4bf40ec888333ba1115798189c0f6