### PR TITLE
Add canvas customizer and variation handling

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,0 +1,92 @@
+(function(){
+  const canvas = document.getElementById('llp-canvas');
+  if (!canvas) {
+    return;
+  }
+  const ctx = canvas.getContext('2d');
+  const fileInput = document.getElementById('llp-upload');
+  const finalizeBtn = document.getElementById('llp-finalize');
+  const addToCartBtn = document.getElementById('add-to-cart');
+  const outputField = document.getElementById('llp_transform');
+
+  let img = new Image();
+  let dragging = false;
+  let lastX = 0;
+  let lastY = 0;
+  let imgX = canvas.width / 2;
+  let imgY = canvas.height / 2;
+  let scale = 1;
+  let rotation = 0;
+
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (!img.src) return;
+    ctx.save();
+    ctx.translate(imgX, imgY);
+    ctx.rotate(rotation);
+    ctx.scale(scale, scale);
+    ctx.drawImage(img, -img.width / 2, -img.height / 2);
+    ctx.restore();
+  }
+
+  fileInput.addEventListener('change', function(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = function(evt) {
+      img = new Image();
+      img.onload = draw;
+      img.src = evt.target.result;
+    };
+    reader.readAsDataURL(file);
+  });
+
+  canvas.addEventListener('mousedown', function(e) {
+    dragging = true;
+    lastX = e.offsetX;
+    lastY = e.offsetY;
+  });
+
+  canvas.addEventListener('mousemove', function(e) {
+    if (!dragging) return;
+    const dx = e.offsetX - lastX;
+    const dy = e.offsetY - lastY;
+    imgX += dx;
+    imgY += dy;
+    lastX = e.offsetX;
+    lastY = e.offsetY;
+    draw();
+  });
+
+  canvas.addEventListener('mouseup', function() { dragging = false; });
+  canvas.addEventListener('mouseleave', function() { dragging = false; });
+
+  canvas.addEventListener('wheel', function(e) {
+    e.preventDefault();
+    if (e.shiftKey) {
+      rotation += e.deltaY * 0.01;
+    } else {
+      const delta = e.deltaY > 0 ? -0.05 : 0.05;
+      scale = Math.max(0.1, scale + delta);
+    }
+    draw();
+  });
+
+  finalizeBtn.addEventListener('click', function(e) {
+    e.preventDefault();
+    const transform = {
+      x: imgX,
+      y: imgY,
+      scale: scale,
+      rotation: rotation
+    };
+    const json = JSON.stringify(transform);
+    if (outputField) {
+      outputField.value = json;
+    }
+    if (addToCartBtn) {
+      addToCartBtn.disabled = false;
+    }
+    document.dispatchEvent(new CustomEvent('llp:transform', { detail: json }));
+  });
+})();

--- a/includes/class-llp-frontend.php
+++ b/includes/class-llp-frontend.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Frontend logic for LLP plugin.
+ */
+
+class LLP_Frontend {
+
+    public function __construct() {
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
+        add_action( 'woocommerce_single_product_summary', [ $this, 'render_customizer' ], 35 );
+        add_filter( 'woocommerce_add_to_cart_validation', [ $this, 'validate_add_to_cart' ], 10, 2 );
+    }
+
+    public function enqueue_scripts() {
+        wp_enqueue_script( 'llp-frontend', plugins_url( '../assets/js/frontend.js', __FILE__ ), [], '1.0', true );
+    }
+
+    public function render_customizer() {
+        if ( ! function_exists( 'wc_get_template' ) ) {
+            return;
+        }
+        global $product;
+        if ( ! $product ) {
+            return;
+        }
+        $mockup_url = get_post_meta( $product->get_id(), '_llp_mockup', true );
+        $mask_url   = get_post_meta( $product->get_id(), '_llp_mask', true );
+        $variations = method_exists( $product, 'get_available_variations' ) ? $product->get_available_variations() : [];
+        wc_get_template( 'single-product/customizer.php', [
+            'mockup_url' => $mockup_url,
+            'mask_url'   => $mask_url,
+            'variations' => $variations,
+        ], '', plugin_dir_path( __DIR__ ) . 'templates/' );
+    }
+
+    public function validate_add_to_cart( $passed, $product_id ) {
+        if ( empty( $_POST['llp_transform'] ) ) {
+            if ( function_exists( 'wc_add_notice' ) ) {
+                wc_add_notice( __( 'Please finalize your design before adding to cart.', 'llp' ), 'error' );
+            }
+            return false;
+        }
+        return $passed;
+    }
+}

--- a/templates/single-product/customizer.php
+++ b/templates/single-product/customizer.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Product customizer template.
+ *
+ * @var array $args Template arguments.
+ */
+
+$mockup_url = isset($mockup_url) ? $mockup_url : '';
+$mask_url   = isset($mask_url) ? $mask_url : '';
+$variations = isset($variations) ? $variations : [];
+?>
+<div class="llp-customizer">
+  <?php if ( $mockup_url ) : ?>
+    <img src="<?php echo esc_url( $mockup_url ); ?>" alt="mockup" class="llp-mockup" />
+  <?php endif; ?>
+  <div class="llp-canvas-wrapper">
+    <canvas id="llp-canvas" width="400" height="400"></canvas>
+    <?php if ( $mask_url ) : ?>
+      <img src="<?php echo esc_url( $mask_url ); ?>" alt="mask" class="llp-mask" />
+    <?php endif; ?>
+  </div>
+  <input type="file" id="llp-upload" accept="image/*" />
+  <button id="llp-finalize" class="button">Finalize</button>
+  <input type="hidden" name="llp_transform" id="llp_transform" />
+  <button type="submit" class="single_add_to_cart_button button alt" id="add-to-cart" disabled>Add to cart</button>
+</div>


### PR DESCRIPTION
## Summary
- Build canvas-based editor for uploading and transforming images
- Add product customizer template with mockup and finalize workflow
- Pass variation data and block cart submission until design is finalized

## Testing
- `node --check assets/js/frontend.js`
- `php -l includes/class-llp-frontend.php`
- `php -l templates/single-product/customizer.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4ccdc9d6c8333beea84db0cf54278