### PR TITLE
Add rotation handles and variation sync

### DIFF
--- a/assets/js/admin-variation.js
+++ b/assets/js/admin-variation.js
@@ -1,0 +1,87 @@
+jQuery(function($){
+    function initVariationEditor($container){
+        var $img   = $container.find('img.variation-preview');
+        var $mask  = $container.find('.llp-mask');
+        var state  = {
+            x: parseFloat($container.data('x')) || 0,
+            y: parseFloat($container.data('y')) || 0,
+            width: parseFloat($container.data('width')) || ($img.length?$img.width():0),
+            height: parseFloat($container.data('height')) || ($img.length?$img.height():0),
+            rotation: parseFloat($container.data('rotation')) || 0,
+            dpi: parseFloat($container.data('dpi')) || 0
+        };
+
+        function apply(){
+            $img.css({
+                transform: 'translate('+state.x+'px,'+state.y+'px) rotate('+state.rotation+'deg)',
+                width: state.width,
+                height: state.height
+            });
+            $container.find('[data-field="x"]').val(state.x.toFixed(2));
+            $container.find('[data-field="y"]').val(state.y.toFixed(2));
+            $container.find('[data-field="width"]').val(state.width.toFixed(2));
+            $container.find('[data-field="height"]').val(state.height.toFixed(2));
+            $container.find('[data-field="rotation"]').val(state.rotation.toFixed(2));
+            $container.find('[data-field="dpi"]').val(state.dpi);
+        }
+
+        // draggable
+        if ($img.draggable) {
+            $img.draggable({
+                stop: function(e,ui){
+                    state.x = ui.position.left;
+                    state.y = ui.position.top;
+                    apply();
+                }
+            });
+        }
+
+        // resizable
+        if ($img.resizable) {
+            $img.resizable({
+                handles: 'ne, se, sw, nw',
+                stop: function(e,ui){
+                    state.width  = ui.size.width;
+                    state.height = ui.size.height;
+                    apply();
+                }
+            });
+        }
+
+        // rotation handle
+        var $rotHandle = $('<div class="llp-rotation-handle"></div>').appendTo($container);
+        $rotHandle.on('mousedown', function(e){
+            e.preventDefault();
+            var center = $img.offset();
+            center.left += $img.outerWidth()/2;
+            center.top  += $img.outerHeight()/2;
+            $(document).on('mousemove.llprotate', function(ev){
+                var angle = Math.atan2(ev.pageY - center.top, ev.pageX - center.left) * 180 / Math.PI;
+                state.rotation = angle;
+                apply();
+            }).on('mouseup.llprotate', function(){
+                $(document).off('.llprotate');
+            });
+        });
+
+        // numeric inputs -> update preview
+        $container.on('input', '.llp-variation-field', function(){
+            var key = $(this).data('field');
+            state[key] = parseFloat($(this).val()) || 0;
+            apply();
+        });
+
+        // mask toggle
+        $container.on('change', '.toggle-mask', function(){
+            if ($mask.length) {
+                $mask.toggle(this.checked);
+            }
+        });
+
+        apply();
+    }
+
+    $('.llp-variation-editor').each(function(){
+        initVariationEditor($(this));
+    });
+});

--- a/includes/class-llp-variation-fields.php
+++ b/includes/class-llp-variation-fields.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Handles custom variation fields for Live Label Preview.
+ */
+class LLP_Variation_Fields {
+
+    public function __construct() {
+        // Render custom fields in variation editor
+        add_action( 'woocommerce_product_after_variable_attributes', array( $this, 'render_fields' ), 10, 3 );
+        // Save values when variation is saved
+        add_action( 'woocommerce_save_product_variation', array( $this, 'save' ), 10, 2 );
+    }
+
+    /**
+     * Output editor container with data attributes and numeric inputs.
+     */
+    public function render_fields( $loop, $variation_data, $variation ) {
+        $fields = array( 'x', 'y', 'width', 'height', 'rotation', 'dpi' );
+        $values = array();
+        foreach ( $fields as $field ) {
+            $values[ $field ] = get_post_meta( $variation->ID, '_llp_' . $field, true );
+        }
+        printf( '<div class="llp-variation-editor" data-x="%1$s" data-y="%2$s" data-width="%3$s" data-height="%4$s" data-rotation="%5$s" data-dpi="%6$s">',
+            esc_attr( $values['x'] ),
+            esc_attr( $values['y'] ),
+            esc_attr( $values['width'] ),
+            esc_attr( $values['height'] ),
+            esc_attr( $values['rotation'] ),
+            esc_attr( $values['dpi'] )
+        );
+        echo '<img class="variation-preview" src="" alt="" />';
+        echo '<div class="llp-mask" style="display:none"></div>';
+        foreach ( $fields as $field ) {
+            printf(
+                '<p class="form-row form-row-full"><label>%1$s</label><input type="number" step="any" class="llp-variation-field" data-field="%2$s" name="llp_variation[%3$d][%2$s]" value="%4$s" /></p>',
+                esc_html( ucfirst( $field ) ),
+                esc_attr( $field ),
+                absint( $loop ),
+                esc_attr( $values[ $field ] )
+            );
+        }
+        echo '<p class="form-row form-row-full"><label><input type="checkbox" class="toggle-mask" /> ' . esc_html__( 'Show mask', 'llp' ) . '</label></p>';
+        echo '</div>';
+    }
+
+    /**
+     * Save the posted variation fields.
+     */
+    public function save( $variation_id, $i ) {
+        if ( empty( $_POST['llp_variation'][ $i ] ) ) {
+            return;
+        }
+        $fields = array( 'x', 'y', 'width', 'height', 'rotation', 'dpi' );
+        foreach ( $fields as $field ) {
+            if ( isset( $_POST['llp_variation'][ $i ][ $field ] ) ) {
+                update_post_meta( $variation_id, '_llp_' . $field, wc_clean( wp_unslash( $_POST['llp_variation'][ $i ][ $field ] ) ) );
+            }
+        }
+    }
+}
+
+new LLP_Variation_Fields();


### PR DESCRIPTION
## Summary
- add draggable, resizable and rotatable controls with live inputs
- sync variation editor fields with WooCommerce and optional mask toggle

## Testing
- `php -l includes/class-llp-variation-fields.php`
- `node --check assets/js/admin-variation.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4cce0185c8333ab8b2177467105ec