### PR TITLE
Add canvas editor customizer with variation validation

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,0 +1,94 @@
+(function(){
+  class CanvasEditor {
+    constructor(wrapper) {
+      this.wrapper = wrapper;
+      this.canvas = wrapper.querySelector('canvas');
+      this.ctx = this.canvas.getContext('2d');
+      this.fileInput = wrapper.querySelector('#llp-upload');
+      this.finalizeButton = wrapper.querySelector('.llp-finalize');
+      this.output = wrapper.querySelector('#llp-composite');
+      this.addToCart = document.querySelector('form.cart button[type="submit"]');
+      this.boundsWidth = parseInt(wrapper.dataset.boundsWidth, 10);
+      this.boundsHeight = parseInt(wrapper.dataset.boundsHeight, 10);
+      this.aspect = parseFloat(wrapper.dataset.aspect);
+      if (this.addToCart) {
+        this.addToCart.disabled = true;
+      }
+      this.bind();
+    }
+
+    bind() {
+      if (this.fileInput) {
+        this.fileInput.addEventListener('change', e => this.loadImage(e));
+      }
+      if (this.finalizeButton) {
+        this.finalizeButton.addEventListener('click', () => this.finalize());
+      }
+    }
+
+    loadImage(e) {
+      const file = e.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = evt => {
+        const img = new Image();
+        img.onload = () => {
+          this.drawImageToCanvas(img);
+        };
+        img.src = evt.target.result;
+      };
+      reader.readAsDataURL(file);
+    }
+
+    drawImageToCanvas(img) {
+      this.canvas.width = this.boundsWidth;
+      this.canvas.height = this.boundsHeight;
+      const targetRatio = this.boundsWidth / this.boundsHeight;
+      let sx = 0, sy = 0, sw = img.width, sh = img.height;
+      const srcRatio = img.width / img.height;
+      if (srcRatio > targetRatio) {
+        sw = img.height * targetRatio;
+        sx = (img.width - sw) / 2;
+      } else {
+        sh = img.width / targetRatio;
+        sy = (img.height - sh) / 2;
+      }
+      this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+      this.ctx.drawImage(img, sx, sy, sw, sh, 0, 0, this.canvas.width, this.canvas.height);
+    }
+
+    finalize() {
+      if (!this.output) return;
+      const tempCanvas = document.createElement('canvas');
+      tempCanvas.width = this.canvas.width;
+      tempCanvas.height = this.canvas.height;
+      const tctx = tempCanvas.getContext('2d');
+      const base = this.wrapper.querySelector('.llp-base');
+      const mockup = this.wrapper.querySelector('.llp-mockup');
+      const mask = this.wrapper.querySelector('.llp-mask');
+      if (base && base.complete) {
+        tctx.drawImage(base, 0, 0, tempCanvas.width, tempCanvas.height);
+      }
+      tctx.drawImage(this.canvas, 0, 0);
+      if (mask && mask.complete) {
+        tctx.globalCompositeOperation = 'destination-in';
+        tctx.drawImage(mask, 0, 0, tempCanvas.width, tempCanvas.height);
+        tctx.globalCompositeOperation = 'source-over';
+      }
+      if (mockup && mockup.complete) {
+        tctx.drawImage(mockup, 0, 0, tempCanvas.width, tempCanvas.height);
+      }
+      this.output.value = tempCanvas.toDataURL('image/png');
+      if (this.addToCart) {
+        this.addToCart.disabled = false;
+      }
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    const wrapper = document.getElementById('llp-customizer');
+    if (wrapper) {
+      new CanvasEditor(wrapper);
+    }
+  });
+})();

--- a/includes/class-llp-frontend.php
+++ b/includes/class-llp-frontend.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Frontend class for the test plugin.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'LLP_Frontend' ) ) {
+    class LLP_Frontend {
+        public function __construct() {
+            add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+            add_action( 'woocommerce_before_add_to_cart_button', array( $this, 'render_customizer' ) );
+            add_filter( 'woocommerce_add_to_cart_validation', array( $this, 'validate_composite' ), 10, 5 );
+        }
+
+        public function enqueue_scripts() {
+            wp_enqueue_script(
+                'llp-frontend',
+                plugins_url( 'assets/js/frontend.js', dirname( __DIR__ ) ),
+                array(),
+                '1.0',
+                true
+            );
+        }
+
+        public function render_customizer() {
+            $variation = array(
+                'bounds' => array( 'width' => 500, 'height' => 500 ),
+                'aspect' => 1,
+                'base'   => 'https://via.placeholder.com/500x500.png?text=Base',
+                'mockup' => 'https://via.placeholder.com/500x500.png?text=Mockup',
+                'mask'   => 'https://via.placeholder.com/500x500.png?text=Mask',
+            );
+
+            wc_get_template(
+                'single-product/customizer.php',
+                array( 'variation' => $variation ),
+                '',
+                plugin_dir_path( __FILE__ ) . '../templates/'
+            );
+        }
+
+        public function validate_composite( $passed, $product_id, $quantity, $variation_id = '', $variations = array() ) {
+            if ( empty( $_POST['llp_composite'] ) ) {
+                wc_add_notice( __( 'Please finalize your design before adding to cart.', 'testplugin' ), 'error' );
+                return false;
+            }
+            return $passed;
+        }
+    }
+}

--- a/templates/single-product/customizer.php
+++ b/templates/single-product/customizer.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Product customizer template
+ *
+ * @var array $variation Variation data passed from LLP_Frontend
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div id="llp-customizer"
+     data-bounds-width="<?php echo esc_attr( $variation['bounds']['width'] ); ?>"
+     data-bounds-height="<?php echo esc_attr( $variation['bounds']['height'] ); ?>"
+     data-aspect="<?php echo esc_attr( $variation['aspect'] ); ?>">
+    <div class="llp-canvas-stack">
+        <img src="<?php echo esc_url( $variation['base'] ); ?>" class="llp-base" alt="" />
+        <canvas width="<?php echo esc_attr( $variation['bounds']['width'] ); ?>" height="<?php echo esc_attr( $variation['bounds']['height'] ); ?>"></canvas>
+        <img src="<?php echo esc_url( $variation['mockup'] ); ?>" class="llp-mockup" alt="" />
+        <img src="<?php echo esc_url( $variation['mask'] ); ?>" class="llp-mask" alt="" style="display:none;" />
+    </div>
+    <input type="file" id="llp-upload" accept="image/*" />
+    <button type="button" class="llp-finalize"><?php esc_html_e( 'Finalize', 'testplugin' ); ?></button>
+    <input type="hidden" name="llp_composite" id="llp-composite" value="" />
+</div>


### PR DESCRIPTION
## Summary
- Replace simple uploader with canvas-based editor enforcing bounds/aspect
- Show base/mockup/mask layers in product customizer and disable cart until finalized
- Pass variation data to template and validate composite before cart submission
- Use placeholder URLs and remove binary images

## Testing
- `php -l includes/class-llp-frontend.php`
- `php -l templates/single-product/customizer.php`
- `node --check assets/js/frontend.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4cf1f42d0833393aca94d0bd60959