### PR TITLE
Add canvas-based image customizer with transform serialization

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,3 +1,8 @@
 #llp-customizer{margin:1em 0;}
 #llp-customizer button{margin-top:0.5em;}
 #llp-preview img{max-width:100%;height:auto;display:block;margin-top:1em;}
+#llp-editor{position:relative;display:none;margin-top:1em;}
+#llp-editor canvas{max-width:100%;}
+#llp-editor img.llp-layer{position:absolute;top:0;left:0;max-width:100%;pointer-events:none;}
+.llp-controls{margin-top:0.5em;}
+.llp-controls button{margin-right:0.5em;}

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,42 +1,155 @@
 (function(){
     const cfg = window.llp_frontend || {};
     document.addEventListener('DOMContentLoaded', () => {
-        const btn = document.getElementById('llp-upload-btn');
-        const file = document.getElementById('llp-upload');
+        const uploadBtn = document.getElementById('llp-upload-btn');
+        const fileInput = document.getElementById('llp-upload');
         const assetField = document.getElementById('llp_asset_id');
         const transformField = document.getElementById('llp_transform');
+        const editor = document.getElementById('llp-editor');
+        const canvas = document.getElementById('llp-canvas');
+        const baseLayer = document.getElementById('llp-base');
+        const maskLayer = document.getElementById('llp-mask');
+        const rotateL = document.getElementById('llp-rotate-left');
+        const rotateR = document.getElementById('llp-rotate-right');
+        const finalizeBtn = document.getElementById('llp-finalize-btn');
         const preview = document.getElementById('llp-preview');
         const addBtn = document.querySelector('form.cart button[type="submit"]');
+
         if (addBtn) { addBtn.disabled = true; }
-        if (!btn || !file) return;
-        btn.addEventListener('click', () => {
-            if (!file.files.length) return;
-            const data = new FormData();
-            data.append('file', file.files[0]);
+        if (!uploadBtn || !fileInput || !canvas) { return; }
+
+        const ctx = canvas.getContext('2d');
+        const state = {img:null, iw:0, ih:0, scale:1, rotation:0, tx:0, ty:0, bounds:null, dragging:false, lastX:0, lastY:0};
+
+        function draw(){
+            if(!state.img || !state.bounds) return;
+            ctx.clearRect(0,0,canvas.width,canvas.height);
+            const b = state.bounds;
+            const cx = b.x + b.w/2 + state.tx;
+            const cy = b.y + b.h/2 + state.ty;
+            ctx.save();
+            ctx.translate(cx, cy);
+            ctx.rotate(state.rotation * Math.PI/180);
+            const w = b.w * state.scale;
+            const h = b.h * state.scale;
+            ctx.drawImage(state.img, -w/2, -h/2, w, h);
+            ctx.restore();
+        }
+
+        function clamp(){
+            const b = state.bounds;
+            const maxX = (state.iw * state.scale - b.w)/2;
+            const maxY = (state.ih * state.scale - b.h)/2;
+            if (maxX < 0) { state.tx = 0; } else { state.tx = Math.max(Math.min(state.tx, maxX), -maxX); }
+            if (maxY < 0) { state.ty = 0; } else { state.ty = Math.max(Math.min(state.ty, maxY), -maxY); }
+        }
+
+        canvas.addEventListener('mousedown', e => {
+            state.dragging = true;
+            state.lastX = e.offsetX;
+            state.lastY = e.offsetY;
+        });
+        document.addEventListener('mouseup', () => { state.dragging = false; });
+        canvas.addEventListener('mousemove', e => {
+            if (!state.dragging) return;
+            state.tx += e.offsetX - state.lastX;
+            state.ty += e.offsetY - state.lastY;
+            state.lastX = e.offsetX;
+            state.lastY = e.offsetY;
+            clamp();
+            draw();
+        });
+        canvas.addEventListener('wheel', e => {
+            e.preventDefault();
+            const delta = e.deltaY < 0 ? 1.1 : 0.9;
+            state.scale *= delta;
+            clamp();
+            draw();
+        });
+
+        if (rotateL) { rotateL.addEventListener('click', () => { state.rotation -= 5; draw(); }); }
+        if (rotateR) { rotateR.addEventListener('click', () => { state.rotation += 5; draw(); }); }
+
+        function setupEditor(vdata){
+            editor.style.display = 'block';
+            baseLayer.src = vdata.base;
+            maskLayer.src = vdata.mask;
+            baseLayer.onload = () => {
+                canvas.width = vdata.base_w || baseLayer.naturalWidth;
+                canvas.height = vdata.base_h || baseLayer.naturalHeight;
+                draw();
+            };
+        }
+
+        uploadBtn.addEventListener('click', () => {
+            if (!fileInput.files.length) return;
             const variationInput = document.querySelector('input[name="variation_id"]');
-            data.append('variation_id', variationInput ? variationInput.value : 0);
+            const variationId = variationInput ? parseInt(variationInput.value) : 0;
+            const vdata = cfg.variations ? cfg.variations[variationId] : null;
+            if (!vdata) return;
+
+            const data = new FormData();
+            data.append('file', fileInput.files[0]);
+            data.append('variation_id', variationId);
             data.append('nonce', cfg.nonce);
             fetch(cfg.upload_url, {method:'POST', credentials:'same-origin', body:data})
                 .then(r => r.json())
                 .then(res => {
                     if (!res.asset_id) return;
                     assetField.value = res.asset_id;
-                    const transform = {scale:1, rotation:0, tx:0, ty:0, crop:{x:0,y:0,w:res.width,h:res.height}};
-                    transformField.value = JSON.stringify(transform);
-                    return fetch(cfg.finalize_url, {
-                        method: 'POST',
-                        credentials: 'same-origin',
-                        headers: {'Content-Type':'application/json'},
-                        body: JSON.stringify({nonce:cfg.nonce, asset_id:res.asset_id, variation_id: variationInput ? variationInput.value : 0, transform: transformField.value})
-                    });
+                    state.iw = res.width;
+                    state.ih = res.height;
+                    state.scale = 1; state.rotation = 0; state.tx = 0; state.ty = 0;
+                    state.bounds = vdata.bounds;
+                    const img = new Image();
+                    img.onload = () => { state.img = img; setupEditor(vdata); draw(); };
+                    img.src = URL.createObjectURL(fileInput.files[0]);
+                });
+        });
+
+        if (finalizeBtn) {
+            finalizeBtn.addEventListener('click', () => {
+                if (!state.img) return;
+                const b = state.bounds;
+                const cropW = b.w / state.scale;
+                const cropH = b.h / state.scale;
+                const cropX = state.iw / 2 - cropW / 2 - state.tx / state.scale;
+                const cropY = state.ih / 2 - cropH / 2 - state.ty / state.scale;
+                const transform = {
+                    scale: state.scale,
+                    rotation: state.rotation,
+                    tx: state.tx,
+                    ty: state.ty,
+                    crop: {
+                        x: Math.round(cropX),
+                        y: Math.round(cropY),
+                        w: Math.round(cropW),
+                        h: Math.round(cropH)
+                    }
+                };
+                transformField.value = JSON.stringify(transform);
+                const variationInput = document.querySelector('input[name="variation_id"]');
+                const variationId = variationInput ? parseInt(variationInput.value) : 0;
+                fetch(cfg.finalize_url, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {'Content-Type':'application/json'},
+                    body: JSON.stringify({
+                        nonce: cfg.nonce,
+                        asset_id: assetField.value,
+                        variation_id: variationId,
+                        transform: transformField.value
+                    })
                 })
-                .then(r => r ? r.json() : null)
+                .then(r => r.json())
                 .then(res => {
                     if (res && res.thumb_url) {
-                        preview.innerHTML = '<img src="' + res.thumb_url + '" style="max-width:150px" />';
+                        preview.innerHTML = '<img src="' + res.thumb_url + '" alt="" />';
                         if (addBtn) { addBtn.disabled = false; }
                     }
                 });
-        });
+            });
+        }
     });
 })();
+

--- a/templates/single-product/customizer.php
+++ b/templates/single-product/customizer.php
@@ -8,12 +8,24 @@
 if (!defined('ABSPATH')) {
     exit;
 }
-
-echo '<div id="llp-customizer">';
 ?>
-<input type="file" id="llp-upload" accept="image/*" />
-<input type="hidden" name="_llp_asset_id" id="llp_asset_id" />
-<input type="hidden" name="_llp_transform" id="llp_transform" />
-<button type="button" id="llp-upload-btn"><?php esc_html_e('Upload Photo', 'llp'); ?></button>
-<div id="llp-preview"></div>
+<div id="llp-customizer">
+    <input type="file" id="llp-upload" accept="image/*" />
+    <input type="hidden" name="_llp_asset_id" id="llp_asset_id" />
+    <input type="hidden" name="_llp_transform" id="llp_transform" />
+    <button type="button" id="llp-upload-btn"><?php esc_html_e('Upload Photo', 'llp'); ?></button>
+
+    <div id="llp-editor">
+        <img id="llp-base" class="llp-layer" alt="" />
+        <canvas id="llp-canvas"></canvas>
+        <img id="llp-mask" class="llp-layer" alt="" />
+        <div class="llp-controls">
+            <button type="button" id="llp-rotate-left">&larr;</button>
+            <button type="button" id="llp-rotate-right">&rarr;</button>
+            <button type="button" id="llp-finalize-btn"><?php esc_html_e('Finalize', 'llp'); ?></button>
+        </div>
+    </div>
+
+    <div id="llp-preview"></div>
 </div>
+


### PR DESCRIPTION
## Summary
- Replace basic upload logic with canvas-based editor supporting drag, zoom, and rotation
- Display layered editor and preview elements in the single-product customizer template
- Localize variation bounds to the frontend and serialize user transform data before finalizing

## Testing
- `php -l includes/class-llp-frontend.php`
- `php -l templates/single-product/customizer.php`
- `node --check assets/js/frontend.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d54f36448333a5b60c326c9804a0