### PR TITLE
Switch asset URLs based on storage mode

### DIFF
--- a/includes/class-llp-frontend.php
+++ b/includes/class-llp-frontend.php
@@ -69,10 +69,10 @@ class Frontend {
             $cart_item_data['_llp_asset_id']  = sanitize_text_field(wp_unslash($_POST['_llp_asset_id']));
             $cart_item_data['_llp_transform'] = wp_unslash($_POST['_llp_transform']);
             $asset_id = $cart_item_data['_llp_asset_id'];
-            $sec = Security::instance();
-            $cart_item_data['_llp_original_url']  = $sec->sign_url($asset_id, 'original.png');
-            $cart_item_data['_llp_composite_url'] = $sec->sign_url($asset_id, 'composite.png');
-            $cart_item_data['_llp_thumb_url']     = $sec->sign_url($asset_id, 'thumb.jpg');
+            $storage = Storage::instance();
+            $cart_item_data['_llp_original_url']  = $storage->asset_url($asset_id, 'original.png');
+            $cart_item_data['_llp_composite_url'] = $storage->asset_url($asset_id, 'composite.png');
+            $cart_item_data['_llp_thumb_url']     = $storage->asset_url($asset_id, 'thumb.jpg');
         }
         return $cart_item_data;
     }
@@ -82,7 +82,7 @@ class Frontend {
      */
     public function display_cart_item_data(array $item_data, array $cart_item): array {
         if (!empty($cart_item['_llp_asset_id'])) {
-            $thumb = Security::instance()->sign_url($cart_item['_llp_asset_id'], 'thumb.jpg');
+            $thumb = Storage::instance()->asset_url($cart_item['_llp_asset_id'], 'thumb.jpg');
             $item_data[] = [
                 'name'  => __('Preview', 'llp'),
                 'value' => '<img src="' . esc_url($thumb) . '" alt="" style="max-width:80px;" />',

--- a/includes/class-llp-order.php
+++ b/includes/class-llp-order.php
@@ -41,7 +41,7 @@ class Order {
         foreach ($order->get_items() as $item) {
             $asset_id = $item->get_meta('_llp_asset_id');
             if ($asset_id) {
-                $thumb = Security::instance()->sign_url($asset_id, 'thumb.jpg');
+                $thumb = Storage::instance()->asset_url($asset_id, 'thumb.jpg');
                 wc_get_template('emails/line-item-preview.php', ['thumb_url' => $thumb], '', LLP_DIR . 'templates/');
             }
         }
@@ -65,7 +65,7 @@ class Order {
         foreach ($order->get_items() as $item) {
             $asset_id = $item->get_meta('_llp_asset_id');
             if ($asset_id) {
-                $thumb = Security::instance()->sign_url($asset_id, 'thumb.jpg');
+                $thumb = Storage::instance()->asset_url($asset_id, 'thumb.jpg');
                 echo '<p><img src="' . esc_url($thumb) . '" style="max-width:100%;" /></p>';
             }
         }

--- a/includes/class-llp-rest.php
+++ b/includes/class-llp-rest.php
@@ -117,12 +117,12 @@ class REST {
             'out_thumb'    => $final_dir . 'thumb.jpg',
         ]);
 
-        $sec = Security::instance();
+        $storage = Storage::instance();
         return rest_ensure_response([
             'asset_id'      => $asset_id,
-            'original_url'  => $sec->sign_url($asset_id, 'original.png'),
-            'composite_url' => $sec->sign_url($asset_id, 'composite.png'),
-            'thumb_url'     => $sec->sign_url($asset_id, 'thumb.jpg'),
+            'original_url'  => $storage->asset_url($asset_id, 'original.png'),
+            'composite_url' => $storage->asset_url($asset_id, 'composite.png'),
+            'thumb_url'     => $storage->asset_url($asset_id, 'thumb.jpg'),
         ]);
     }
 

--- a/includes/class-llp-security.php
+++ b/includes/class-llp-security.php
@@ -53,6 +53,9 @@ class Security {
      * Generate a signed URL for downloading an asset.
      */
     public function sign_url(string $asset_id, string $file, int $expires = 0): string {
+        if (Settings::instance()->get('storage') === 'public') {
+            return Storage::instance()->asset_url($asset_id, $file);
+        }
         $expires = $expires ?: time() + DAY_IN_SECONDS;
         $secret  = wp_salt('llp');
         $token   = hash_hmac('sha256', $asset_id . '|' . $file . '|' . $expires, $secret);

--- a/includes/class-llp-storage.php
+++ b/includes/class-llp-storage.php
@@ -59,6 +59,9 @@ class Storage {
      * Asset URL.
      */
     public function asset_url(string $asset_id, string $file): string {
+        if (Settings::instance()->get('storage') === 'private') {
+            return Security::instance()->sign_url($asset_id, $file);
+        }
         return trailingslashit($this->base_url()) . $asset_id . '/' . $file;
     }
 


### PR DESCRIPTION
## Summary
- Build asset URLs with public or signed variants depending on storage setting
- Update frontend, order, and REST handlers to generate URLs through storage helper

## Testing
- `php -l includes/class-llp-storage.php`
- `php -l includes/class-llp-security.php`
- `php -l includes/class-llp-frontend.php`
- `php -l includes/class-llp-order.php`
- `php -l includes/class-llp-rest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4d55416508333be06ae728a797fd3