### PR TITLE
Skip tmp assets and clean up abandoned uploads

### DIFF
--- a/includes/class-llp-cron.php
+++ b/includes/class-llp-cron.php
@@ -40,11 +40,35 @@ class Cron {
         $cutoff = time() - DAY_IN_SECONDS * $days;
         $dir = Storage::instance()->base_dir();
         foreach (glob($dir . '*/', GLOB_ONLYDIR) as $asset_dir) {
+            if (basename($asset_dir) === 'tmp') {
+                continue;
+            }
             if (filemtime($asset_dir) < $cutoff) {
                 foreach (glob($asset_dir . '*') as $file) {
                     @unlink($file);
                 }
                 @rmdir($asset_dir);
+            }
+        }
+
+        $this->purge_temp();
+    }
+
+    /**
+     * Remove abandoned temporary uploads.
+     */
+    private function purge_temp(): void {
+        $cutoff = time() - DAY_IN_SECONDS;
+        $dir    = trailingslashit(Storage::instance()->base_dir() . 'tmp/');
+        if (!file_exists($dir)) {
+            return;
+        }
+        foreach (glob($dir . '*/', GLOB_ONLYDIR) as $tmp_dir) {
+            if (filemtime($tmp_dir) < $cutoff) {
+                foreach (glob($tmp_dir . '*') as $file) {
+                    @unlink($file);
+                }
+                @rmdir($tmp_dir);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Avoid purging tmp directory when cleaning old assets
- Clean up stale temp uploads separately

## Testing
- `php -l includes/class-llp-cron.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4d5548ab48333adb165c365cd6afe