### PR TITLE
Persist upload metadata and variation snapshot

### DIFF
--- a/includes/class-llp-frontend.php
+++ b/includes/class-llp-frontend.php
@@ -94,6 +94,17 @@ class Frontend {
             $cart_item_data['_llp_original_url']  = $sec->sign_url($asset_id, 'original.png');
             $cart_item_data['_llp_composite_url'] = $sec->sign_url($asset_id, 'composite.png');
             $cart_item_data['_llp_thumb_url']     = $sec->sign_url($asset_id, 'thumb.jpg');
+
+            $meta = json_decode(@file_get_contents(Storage::instance()->asset_dir($asset_id) . 'meta.json'), true) ?: [];
+            $cart_item_data['_llp_original_sha256'] = $meta['sha256'] ?? '';
+            $cart_item_data['_llp_processor']       = $meta['renderer'] ?? '';
+
+            $keys = ['_llp_base_image_id', '_llp_mask_image_id', '_llp_bounds', '_llp_output_dpi', '_llp_aspect_ratio', '_llp_min_resolution'];
+            $settings = [];
+            foreach ($keys as $key) {
+                $settings[$key] = get_post_meta($variation_id, $key, true);
+            }
+            $cart_item_data['_llp_variation_settings'] = $settings;
         }
         return $cart_item_data;
     }
@@ -116,7 +127,7 @@ class Frontend {
      * Restore cart item from session.
      */
     public function restore_cart_item(array $cart_item, array $session_values): array {
-        foreach (['_llp_asset_id', '_llp_transform', '_llp_original_url', '_llp_composite_url', '_llp_thumb_url'] as $key) {
+        foreach (['_llp_asset_id', '_llp_transform', '_llp_original_url', '_llp_composite_url', '_llp_thumb_url', '_llp_original_sha256', '_llp_processor', '_llp_variation_settings'] as $key) {
             if (isset($session_values[$key])) {
                 $cart_item[$key] = $session_values[$key];
             }

--- a/includes/class-llp-order.php
+++ b/includes/class-llp-order.php
@@ -23,7 +23,7 @@ class Order {
      * Persist order item meta on checkout.
      */
     public function persist_order_item_meta($item, string $cart_item_key, array $values, $order_id): void {
-        $keys = ['_llp_asset_id', '_llp_transform', '_llp_original_url', '_llp_composite_url', '_llp_thumb_url'];
+        $keys = ['_llp_asset_id', '_llp_transform', '_llp_original_url', '_llp_composite_url', '_llp_thumb_url', '_llp_original_sha256', '_llp_processor', '_llp_variation_settings'];
         foreach ($keys as $key) {
             if (isset($values[$key])) {
                 $item->add_meta_data($key, $values[$key], true);

--- a/includes/class-llp-renderer.php
+++ b/includes/class-llp-renderer.php
@@ -16,8 +16,10 @@ class Renderer {
      * Render composite image based on settings.
      *
      * @param array $args Rendering arguments.
+     *
+     * @return string|false Renderer type on success, false on failure.
      */
-    public function render(array $args): bool {
+    public function render(array $args) {
         $base_path    = $args['base_path'];
         $mask_path    = $args['mask_path'] ?? null;
         $user_path    = $args['user_img'];
@@ -68,7 +70,7 @@ class Renderer {
                 $thumb->thumbnailImage(800, 0);
                 $thumb->setImageFormat('jpeg');
                 $thumb->writeImage($thumb_out);
-                return true;
+                return 'imagick';
             } catch (\Exception $e) {
                 return false;
             }
@@ -100,6 +102,6 @@ class Renderer {
         imagedestroy($thumb);
         imagedestroy($user);
         imagedestroy($base);
-        return true;
+        return 'gd';
     }
 }


### PR DESCRIPTION
## Summary
- Save upload hash during finalization and record transform and renderer metadata
- Include SHA256, processor type, and variation settings in cart data and order meta
- Expose renderer type from Renderer::render

## Testing
- `php -l includes/class-llp-renderer.php`
- `php -l includes/class-llp-rest.php`
- `php -l includes/class-llp-frontend.php`
- `php -l includes/class-llp-order.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd104c948333b3be74b133b64e6a