### PR TITLE
Allow guest uploads via nonce and signed URLs

### DIFF
--- a/includes/class-llp-rest.php
+++ b/includes/class-llp-rest.php
@@ -70,15 +70,16 @@ class REST {
      * Permission check for mutating requests.
      */
     public function permission_check(\WP_REST_Request $request) {
-        if (!wp_verify_nonce($request->get_param('nonce'), 'llp')) {
+        $nonce = $request->get_param('nonce');
+        if (!wp_verify_nonce($nonce, 'llp')) {
             return new \WP_Error('invalid_nonce', __('Invalid nonce', 'llp'), ['status' => 403]);
         }
-        $settings = Settings::instance();
-        if ('private' === $settings->get('storage')) {
-            if (!is_user_logged_in() || !current_user_can('upload_files')) {
-                return new \WP_Error('forbidden', __('Authentication required.', 'llp'), ['status' => 401]);
-            }
+
+        $allowed = apply_filters('llp_rest_permission', true, $request);
+        if (!$allowed) {
+            return new \WP_Error('forbidden', __('Uploads are disabled.', 'llp'), ['status' => 403]);
         }
+
         return true;
     }
 

--- a/includes/class-llp-security.php
+++ b/includes/class-llp-security.php
@@ -79,9 +79,17 @@ class Security {
     }
 
     /**
-     * Generate a signed URL for downloading an asset.
+     * Generate a URL for downloading an asset.
+     *
+     * Uses signed REST URLs when storage is private, otherwise returns the
+     * public asset URL.
      */
     public function sign_url(string $asset_id, string $file, int $expires = 0): string {
+        $settings = Settings::instance();
+        if ('public' === $settings->get('storage')) {
+            return Storage::instance()->asset_url($asset_id, $file);
+        }
+
         $expires = $expires ?: time() + DAY_IN_SECONDS;
         $secret  = wp_salt('llp');
         $token   = hash_hmac('sha256', $asset_id . '|' . $file . '|' . $expires, $secret);


### PR DESCRIPTION
## Summary
- replace capability check with nonce validation and filterable permission to allow guest uploads
- serve private files through signed URLs while returning direct links for public storage

## Testing
- `php -l includes/class-llp-rest.php`
- `php -l includes/class-llp-security.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd147a3083339d22bb3b3285d439