### PR TITLE
Enhance admin placement editor and order tools

### DIFF
--- a/assets/js/admin-variation.js
+++ b/assets/js/admin-variation.js
@@ -18,6 +18,10 @@
                 var baseField = document.getElementById('llp_base_image_id_'+loop);
                 if(!baseField || !baseField.value){ alert('Select base image first'); return; }
                 var url = wp.media.attachment(baseField.value).get('url');
+                var maskField = document.getElementById('llp_mask_image_id_'+loop);
+                var maskUrl = maskField && maskField.value ? wp.media.attachment(maskField.value).get('url') : '';
+                var rotationField = document.getElementById('llp_bounds_rotation_'+loop);
+                var rotation = parseFloat(rotationField && rotationField.value ? rotationField.value : 0);
                 var bounds = {
                     x: parseInt(document.getElementById('llp_bounds_x_'+loop).value || 0,10),
                     y: parseInt(document.getElementById('llp_bounds_y_'+loop).value || 0,10),
@@ -26,7 +30,7 @@
                 };
                 var modal = document.createElement('div');
                 modal.className = 'llp-editor-modal';
-                modal.innerHTML = '<div class="llp-editor-backdrop"></div><div class="llp-editor-content"><div class="llp-editor-stage"><img src="'+url+'" class="llp-editor-base"/><div class="llp-rect" style="left:'+bounds.x+'px;top:'+bounds.y+'px;width:'+bounds.w+'px;height:'+bounds.h+'px;"></div></div><p><button type="button" class="button llp-editor-close">'+llpAdmin.closeText+'</button></p></div>';
+                modal.innerHTML = '<div class="llp-editor-backdrop"></div><div class="llp-editor-content"><div class="llp-editor-stage"><img src="'+url+'" class="llp-editor-base"/>'+(maskUrl ? '<img src="'+maskUrl+'" class="llp-editor-mask" style="position:absolute;top:0;left:0;opacity:0.5;pointer-events:none;"/>' : '')+'<div class="llp-rect" style="left:'+bounds.x+'px;top:'+bounds.y+'px;width:'+bounds.w+'px;height:'+bounds.h+'px;transform:rotate('+rotation+'deg);"></div></div><p><button type="button" class="button llp-editor-close">'+llpAdmin.closeText+'</button></p></div>';
                 document.body.appendChild(modal);
                 var rect = modal.querySelector('.llp-rect');
                 var stage = modal.querySelector('.llp-editor-stage');
@@ -46,8 +50,10 @@
                 rect.addEventListener('dblclick', function(){
                     var w = parseInt(prompt(llpAdmin.widthText, rect.offsetWidth),10);
                     var h = parseInt(prompt(llpAdmin.heightText, rect.offsetHeight),10);
-                    if(w){ rect.style.width=w+'px'; document.getElementById('llp_bounds_w_'+loop).value=w; }
-                    if(h){ rect.style.height=h+'px'; document.getElementById('llp_bounds_h_'+loop).value=h; }
+                    var r = parseFloat(prompt(llpAdmin.rotationText, rotation));
+                    if(!isNaN(w)){ rect.style.width=w+'px'; document.getElementById('llp_bounds_w_'+loop).value=w; }
+                    if(!isNaN(h)){ rect.style.height=h+'px'; document.getElementById('llp_bounds_h_'+loop).value=h; }
+                    if(!isNaN(r)){ rotation=r; rect.style.transform='rotate('+r+'deg)'; rotationField.value=r; }
                 });
                 modal.querySelector('.llp-editor-close').addEventListener('click', function(){ modal.remove(); });
             });

--- a/includes/class-llp-order.php
+++ b/includes/class-llp-order.php
@@ -17,6 +17,7 @@ class Order {
         add_action('woocommerce_email_after_order_table', [$this, 'email_thumbs'], 10, 4);
         add_action('add_meta_boxes', [$this, 'meta_box']);
         add_action('admin_post_llp_purge_order', [$this, 'handle_purge']);
+        add_action('admin_post_llp_rerender', [$this, 'handle_rerender']);
     }
 
     /**
@@ -65,8 +66,20 @@ class Order {
         foreach ($order->get_items() as $item) {
             $asset_id = $item->get_meta('_llp_asset_id');
             if ($asset_id) {
-                $thumb = Security::instance()->sign_url($asset_id, 'thumb.jpg');
+                $sec   = Security::instance();
+                $thumb = $sec->sign_url($asset_id, 'thumb.jpg');
+                $orig  = $sec->sign_url($asset_id, 'original.png');
+                $comp  = $sec->sign_url($asset_id, 'composite.png');
                 echo '<p><img src="' . esc_url($thumb) . '" style="max-width:100%;" /></p>';
+                $rerender_url = wp_nonce_url(
+                    admin_url('admin-post.php?action=llp_rerender&order_id=' . $post->ID . '&item_id=' . $item->get_id()),
+                    'llp_rerender_order'
+                );
+                echo '<p>';
+                echo '<a class="button" href="' . esc_url($orig) . '" target="_blank">' . esc_html__('Original', 'llp') . '</a> ';
+                echo '<a class="button" href="' . esc_url($comp) . '" target="_blank">' . esc_html__('Composite', 'llp') . '</a> ';
+                echo '<a class="button" href="' . esc_url($rerender_url) . '">' . esc_html__('Re-render', 'llp') . '</a>';
+                echo '</p>';
             }
         }
         $url = wp_nonce_url(admin_url('admin-post.php?action=llp_purge_order&order_id=' . $post->ID), 'llp_purge_order');
@@ -93,6 +106,73 @@ class Order {
                 }
             }
         }
+        wp_safe_redirect(wp_get_referer() ?: admin_url('post.php?post=' . $order_id . '&action=edit'));
+        exit;
+    }
+
+    /**
+     * Handle re-render request from order screen.
+     */
+    public function handle_rerender(): void {
+        if (!current_user_can('edit_shop_orders')) {
+            wp_die(__('Permission denied', 'llp'));
+        }
+        $order_id = absint($_GET['order_id'] ?? 0);
+        $item_id  = absint($_GET['item_id'] ?? 0);
+        if (!$order_id || !$item_id || !wp_verify_nonce($_GET['_wpnonce'] ?? '', 'llp_rerender_order')) {
+            wp_die(__('Invalid request', 'llp'));
+        }
+        $order = wc_get_order($order_id);
+        if (!$order) {
+            wp_die(__('Invalid order', 'llp'));
+        }
+        $item = $order->get_item($item_id);
+        if (!$item) {
+            wp_die(__('Invalid item', 'llp'));
+        }
+        $asset_id  = $item->get_meta('_llp_asset_id');
+        $transform = json_decode((string) $item->get_meta('_llp_transform'), true) ?: [];
+        if (!$asset_id || empty($transform)) {
+            wp_die(__('Missing data', 'llp'));
+        }
+
+        $variation_id = $item->get_variation_id() ?: $item->get_product_id();
+        $base_id = (int) get_post_meta($variation_id, '_llp_base_image_id', true);
+        $mask_id = (int) get_post_meta($variation_id, '_llp_mask_image_id', true);
+        $bounds  = json_decode((string) get_post_meta($variation_id, '_llp_bounds', true), true) ?: [];
+        $dpi     = (int) get_post_meta($variation_id, '_llp_output_dpi', true) ?: 300;
+        if (!$base_id || empty($bounds)) {
+            wp_die(__('Variation not configured', 'llp'));
+        }
+        $base_path = get_attached_file($base_id);
+        if (!$base_path || !file_exists($base_path)) {
+            wp_die(__('Base image not found', 'llp'));
+        }
+        $mask_path = null;
+        if ($mask_id) {
+            $mask_path = get_attached_file($mask_id);
+            if (!$mask_path || !file_exists($mask_path)) {
+                $mask_path = null;
+            }
+        }
+
+        $dir = Storage::instance()->asset_dir($asset_id);
+        Renderer::instance()->render([
+            'base_path'    => $base_path,
+            'mask_path'    => $mask_path,
+            'user_img'     => $dir . 'original.png',
+            'bounds'       => $bounds,
+            'transform'    => $transform,
+            'output_dpi'   => $dpi,
+            'out_composite'=> $dir . 'composite.png',
+            'out_thumb'    => $dir . 'thumb.jpg',
+        ]);
+
+        $sec = Security::instance();
+        $item->update_meta_data('_llp_composite_url', $sec->sign_url($asset_id, 'composite.png'));
+        $item->update_meta_data('_llp_thumb_url', $sec->sign_url($asset_id, 'thumb.jpg'));
+        $item->save_meta_data();
+
         wp_safe_redirect(wp_get_referer() ?: admin_url('post.php?post=' . $order_id . '&action=edit'));
         exit;
     }

--- a/includes/class-llp-variation-fields.php
+++ b/includes/class-llp-variation-fields.php
@@ -35,6 +35,7 @@ class Variation_Fields {
             'closeText'  => __('Close', 'llp'),
             'widthText'  => __('Width (px)', 'llp'),
             'heightText' => __('Height (px)', 'llp'),
+            'rotationText' => __('Rotation (deg)', 'llp'),
         ]);
         wp_enqueue_style('llp-admin', LLP_URL . 'assets/css/admin.css', [], LLP_VER);
     }


### PR DESCRIPTION
## Summary
- Allow viewing original and composite images from order admin with re-render capability
- Support rotation and mask overlay preview in variation placement editor

## Testing
- `php -l includes/class-llp-order.php`
- `php -l includes/class-llp-variation-fields.php`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dd1221b8833398fbb58617d11f3b