### PR TITLE
Support public storage URLs

### DIFF
--- a/includes/class-llp-frontend.php
+++ b/includes/class-llp-frontend.php
@@ -90,10 +90,15 @@ class Frontend {
             $cart_item_data['_llp_asset_id']  = sanitize_text_field(wp_unslash($_POST['_llp_asset_id']));
             $cart_item_data['_llp_transform'] = wp_unslash($_POST['_llp_transform']);
             $asset_id = $cart_item_data['_llp_asset_id'];
-            $sec = Security::instance();
-            $cart_item_data['_llp_original_url']  = $sec->sign_url($asset_id, 'original.png');
-            $cart_item_data['_llp_composite_url'] = $sec->sign_url($asset_id, 'composite.png');
-            $cart_item_data['_llp_thumb_url']     = $sec->sign_url($asset_id, 'thumb.jpg');
+            $sec      = Security::instance();
+            $files    = [
+                '_llp_original_url'  => 'original.png',
+                '_llp_composite_url' => 'composite.png',
+                '_llp_thumb_url'     => 'thumb.jpg',
+            ];
+            foreach ($files as $key => $file) {
+                $cart_item_data[$key] = $sec->sign_url($asset_id, $file);
+            }
         }
         return $cart_item_data;
     }
@@ -116,10 +121,17 @@ class Frontend {
      * Restore cart item from session.
      */
     public function restore_cart_item(array $cart_item, array $session_values): array {
-        foreach (['_llp_asset_id', '_llp_transform', '_llp_original_url', '_llp_composite_url', '_llp_thumb_url'] as $key) {
+        foreach (['_llp_asset_id', '_llp_transform'] as $key) {
             if (isset($session_values[$key])) {
                 $cart_item[$key] = $session_values[$key];
             }
+        }
+        if (!empty($cart_item['_llp_asset_id'])) {
+            $sec      = Security::instance();
+            $asset_id = $cart_item['_llp_asset_id'];
+            $cart_item['_llp_original_url']  = $sec->sign_url($asset_id, 'original.png');
+            $cart_item['_llp_composite_url'] = $sec->sign_url($asset_id, 'composite.png');
+            $cart_item['_llp_thumb_url']     = $sec->sign_url($asset_id, 'thumb.jpg');
         }
         return $cart_item;
     }

--- a/includes/class-llp-frontend.php
+++ b/includes/class-llp-frontend.php
@@ -99,6 +99,17 @@ class Frontend {
             foreach ($files as $key => $file) {
                 $cart_item_data[$key] = $sec->sign_url($asset_id, $file);
             }
+
+            $meta = json_decode(@file_get_contents(Storage::instance()->asset_dir($asset_id) . 'meta.json'), true) ?: [];
+            $cart_item_data['_llp_original_sha256'] = $meta['sha256'] ?? '';
+            $cart_item_data['_llp_processor']       = $meta['renderer'] ?? '';
+
+            $keys = ['_llp_base_image_id', '_llp_mask_image_id', '_llp_bounds', '_llp_output_dpi', '_llp_aspect_ratio', '_llp_min_resolution'];
+            $settings = [];
+            foreach ($keys as $key) {
+                $settings[$key] = get_post_meta($variation_id, $key, true);
+            }
+            $cart_item_data['_llp_variation_settings'] = $settings;
         }
         return $cart_item_data;
     }
@@ -121,7 +132,7 @@ class Frontend {
      * Restore cart item from session.
      */
     public function restore_cart_item(array $cart_item, array $session_values): array {
-        foreach (['_llp_asset_id', '_llp_transform'] as $key) {
+        foreach (['_llp_asset_id', '_llp_transform', '_llp_original_sha256', '_llp_processor', '_llp_variation_settings'] as $key) {
             if (isset($session_values[$key])) {
                 $cart_item[$key] = $session_values[$key];
             }

--- a/includes/class-llp-frontend.php
+++ b/includes/class-llp-frontend.php
@@ -91,14 +91,9 @@ class Frontend {
             $cart_item_data['_llp_transform'] = wp_unslash($_POST['_llp_transform']);
             $asset_id = $cart_item_data['_llp_asset_id'];
             $sec      = Security::instance();
-            $files    = [
-                '_llp_original_url'  => 'original.png',
-                '_llp_composite_url' => 'composite.png',
-                '_llp_thumb_url'     => 'thumb.jpg',
-            ];
-            foreach ($files as $key => $file) {
-                $cart_item_data[$key] = $sec->sign_url($asset_id, $file);
-            }
+            $cart_item_data['_llp_original_url']  = $sec->sign_url($asset_id, 'original.png');
+            $cart_item_data['_llp_composite_url'] = $sec->sign_url($asset_id, 'composite.png');
+            $cart_item_data['_llp_thumb_url']     = $sec->sign_url($asset_id, 'thumb.jpg');
 
             $meta = json_decode(@file_get_contents(Storage::instance()->asset_dir($asset_id) . 'meta.json'), true) ?: [];
             $cart_item_data['_llp_original_sha256'] = $meta['sha256'] ?? '';
@@ -119,7 +114,8 @@ class Frontend {
      */
     public function display_cart_item_data(array $item_data, array $cart_item): array {
         if (!empty($cart_item['_llp_asset_id'])) {
-            $thumb = Security::instance()->sign_url($cart_item['_llp_asset_id'], 'thumb.jpg');
+            $sec   = Security::instance();
+            $thumb = $sec->sign_url($cart_item['_llp_asset_id'], 'thumb.jpg');
             $item_data[] = [
                 'name'  => __('Preview', 'llp'),
                 'value' => '<img src="' . esc_url($thumb) . '" alt="" style="max-width:80px;" />',

--- a/includes/class-llp-frontend.php
+++ b/includes/class-llp-frontend.php
@@ -128,7 +128,7 @@ class Frontend {
      * Restore cart item from session.
      */
     public function restore_cart_item(array $cart_item, array $session_values): array {
-        foreach (['_llp_asset_id', '_llp_transform', '_llp_original_sha256', '_llp_processor', '_llp_variation_settings'] as $key) {
+        foreach (['_llp_asset_id', '_llp_transform', '_llp_original_url', '_llp_composite_url', '_llp_thumb_url', '_llp_original_sha256', '_llp_processor', '_llp_variation_settings'] as $key) {
             if (isset($session_values[$key])) {
                 $cart_item[$key] = $session_values[$key];
             }

--- a/includes/class-llp-order.php
+++ b/includes/class-llp-order.php
@@ -17,13 +17,14 @@ class Order {
         add_action('woocommerce_email_after_order_table', [$this, 'email_thumbs'], 10, 4);
         add_action('add_meta_boxes', [$this, 'meta_box']);
         add_action('admin_post_llp_purge_order', [$this, 'handle_purge']);
+        add_action('admin_post_llp_rerender', [$this, 'handle_rerender']);
     }
 
     /**
      * Persist order item meta on checkout.
      */
     public function persist_order_item_meta($item, string $cart_item_key, array $values, $order_id): void {
-        $keys = ['_llp_asset_id', '_llp_transform', '_llp_original_url', '_llp_composite_url', '_llp_thumb_url'];
+        $keys = ['_llp_asset_id', '_llp_transform', '_llp_original_url', '_llp_composite_url', '_llp_thumb_url', '_llp_original_sha256', '_llp_processor', '_llp_variation_settings'];
         foreach ($keys as $key) {
             if (isset($values[$key])) {
                 $item->add_meta_data($key, $values[$key], true);
@@ -68,7 +69,18 @@ class Order {
             $asset_id = $item->get_meta('_llp_asset_id');
             if ($asset_id) {
                 $thumb = $sec->sign_url($asset_id, 'thumb.jpg');
+                $orig  = $sec->sign_url($asset_id, 'original.png');
+                $comp  = $sec->sign_url($asset_id, 'composite.png');
                 echo '<p><img src="' . esc_url($thumb) . '" style="max-width:100%;" /></p>';
+                $rerender_url = wp_nonce_url(
+                    admin_url('admin-post.php?action=llp_rerender&order_id=' . $post->ID . '&item_id=' . $item->get_id()),
+                    'llp_rerender_order'
+                );
+                echo '<p>';
+                echo '<a class="button" href="' . esc_url($orig) . '" target="_blank">' . esc_html__('Original', 'llp') . '</a> ';
+                echo '<a class="button" href="' . esc_url($comp) . '" target="_blank">' . esc_html__('Composite', 'llp') . '</a> ';
+                echo '<a class="button" href="' . esc_url($rerender_url) . '">' . esc_html__('Re-render', 'llp') . '</a>';
+                echo '</p>';
             }
         }
         $url = wp_nonce_url(admin_url('admin-post.php?action=llp_purge_order&order_id=' . $post->ID), 'llp_purge_order');
@@ -95,6 +107,73 @@ class Order {
                 }
             }
         }
+        wp_safe_redirect(wp_get_referer() ?: admin_url('post.php?post=' . $order_id . '&action=edit'));
+        exit;
+    }
+
+    /**
+     * Handle re-render request from order screen.
+     */
+    public function handle_rerender(): void {
+        if (!current_user_can('edit_shop_orders')) {
+            wp_die(__('Permission denied', 'llp'));
+        }
+        $order_id = absint($_GET['order_id'] ?? 0);
+        $item_id  = absint($_GET['item_id'] ?? 0);
+        if (!$order_id || !$item_id || !wp_verify_nonce($_GET['_wpnonce'] ?? '', 'llp_rerender_order')) {
+            wp_die(__('Invalid request', 'llp'));
+        }
+        $order = wc_get_order($order_id);
+        if (!$order) {
+            wp_die(__('Invalid order', 'llp'));
+        }
+        $item = $order->get_item($item_id);
+        if (!$item) {
+            wp_die(__('Invalid item', 'llp'));
+        }
+        $asset_id  = $item->get_meta('_llp_asset_id');
+        $transform = json_decode((string) $item->get_meta('_llp_transform'), true) ?: [];
+        if (!$asset_id || empty($transform)) {
+            wp_die(__('Missing data', 'llp'));
+        }
+
+        $variation_id = $item->get_variation_id() ?: $item->get_product_id();
+        $base_id = (int) get_post_meta($variation_id, '_llp_base_image_id', true);
+        $mask_id = (int) get_post_meta($variation_id, '_llp_mask_image_id', true);
+        $bounds  = json_decode((string) get_post_meta($variation_id, '_llp_bounds', true), true) ?: [];
+        $dpi     = (int) get_post_meta($variation_id, '_llp_output_dpi', true) ?: 300;
+        if (!$base_id || empty($bounds)) {
+            wp_die(__('Variation not configured', 'llp'));
+        }
+        $base_path = get_attached_file($base_id);
+        if (!$base_path || !file_exists($base_path)) {
+            wp_die(__('Base image not found', 'llp'));
+        }
+        $mask_path = null;
+        if ($mask_id) {
+            $mask_path = get_attached_file($mask_id);
+            if (!$mask_path || !file_exists($mask_path)) {
+                $mask_path = null;
+            }
+        }
+
+        $dir = Storage::instance()->asset_dir($asset_id);
+        Renderer::instance()->render([
+            'base_path'    => $base_path,
+            'mask_path'    => $mask_path,
+            'user_img'     => $dir . 'original.png',
+            'bounds'       => $bounds,
+            'transform'    => $transform,
+            'output_dpi'   => $dpi,
+            'out_composite'=> $dir . 'composite.png',
+            'out_thumb'    => $dir . 'thumb.jpg',
+        ]);
+
+        $sec = Security::instance();
+        $item->update_meta_data('_llp_composite_url', $sec->sign_url($asset_id, 'composite.png'));
+        $item->update_meta_data('_llp_thumb_url', $sec->sign_url($asset_id, 'thumb.jpg'));
+        $item->save_meta_data();
+
         wp_safe_redirect(wp_get_referer() ?: admin_url('post.php?post=' . $order_id . '&action=edit'));
         exit;
     }

--- a/includes/class-llp-order.php
+++ b/includes/class-llp-order.php
@@ -38,10 +38,11 @@ class Order {
         if ($plain_text) {
             return;
         }
+        $sec = Security::instance();
         foreach ($order->get_items() as $item) {
             $asset_id = $item->get_meta('_llp_asset_id');
             if ($asset_id) {
-                $thumb = Security::instance()->sign_url($asset_id, 'thumb.jpg');
+                $thumb = $sec->sign_url($asset_id, 'thumb.jpg');
                 wc_get_template('emails/line-item-preview.php', ['thumb_url' => $thumb], '', LLP_DIR . 'templates/');
             }
         }
@@ -62,10 +63,11 @@ class Order {
         if (!$order) {
             return;
         }
+        $sec = Security::instance();
         foreach ($order->get_items() as $item) {
             $asset_id = $item->get_meta('_llp_asset_id');
             if ($asset_id) {
-                $thumb = Security::instance()->sign_url($asset_id, 'thumb.jpg');
+                $thumb = $sec->sign_url($asset_id, 'thumb.jpg');
                 echo '<p><img src="' . esc_url($thumb) . '" style="max-width:100%;" /></p>';
             }
         }

--- a/includes/class-llp-security.php
+++ b/includes/class-llp-security.php
@@ -82,6 +82,11 @@ class Security {
      * Generate a signed URL for downloading an asset.
      */
     public function sign_url(string $asset_id, string $file, int $expires = 0): string {
+        $settings = Settings::instance();
+        if ('public' === $settings->get('storage')) {
+            return Storage::instance()->asset_url($asset_id, $file);
+        }
+
         $expires = $expires ?: time() + DAY_IN_SECONDS;
         $secret  = wp_salt('llp');
         $token   = hash_hmac('sha256', $asset_id . '|' . $file . '|' . $expires, $secret);

--- a/includes/class-llp-storage.php
+++ b/includes/class-llp-storage.php
@@ -27,6 +27,19 @@ class Storage {
     public function base_dir(): string {
         $dir = LLP_UPLOAD_DIR;
         $this->ensure($dir);
+
+        if ('private' === Settings::instance()->get('storage')) {
+            $htaccess = $dir . '.htaccess';
+            if (!file_exists($htaccess)) {
+                file_put_contents($htaccess, "Require all denied\n");
+            }
+            $webconfig = $dir . 'web.config';
+            if (!file_exists($webconfig)) {
+                $deny = '<configuration><system.webServer><authorization><deny users="*" /></authorization></system.webServer></configuration>';
+                file_put_contents($webconfig, $deny);
+            }
+        }
+
         return $dir;
     }
 


### PR DESCRIPTION
## Summary
- Return direct asset URLs when storage is public and keep signed REST URLs for private storage
- Protect private storage directories with .htaccess and web.config files
- Refresh asset URLs when restoring cart items and streamline URL generation in email previews

## Testing
- `php -l includes/class-llp-security.php`
- `php -l includes/class-llp-storage.php`
- `php -l includes/class-llp-frontend.php`
- `php -l includes/class-llp-order.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd0ddf148333bb230341e1f3126b