### PR TITLE
Apply mask in GD renderer

### DIFF
--- a/includes/class-llp-renderer.php
+++ b/includes/class-llp-renderer.php
@@ -80,19 +80,78 @@ class Renderer {
         if (!$base || !$user) {
             return false;
         }
-        $canvas = $base;
+        $canvas   = $base;
         $scaled_w = (int) ($bounds['w'] * $transform['scale']);
         $scaled_h = (int) ($bounds['h'] * $transform['scale']);
-        $tmp = imagecreatetruecolor($scaled_w, $scaled_h);
+        $tmp      = imagecreatetruecolor($scaled_w, $scaled_h);
         imagealphablending($tmp, false);
         imagesavealpha($tmp, true);
-        imagecopyresampled($tmp, $user, 0, 0, $transform['crop']['x'] ?? 0, $transform['crop']['y'] ?? 0, $scaled_w, $scaled_h, $transform['crop']['w'] ?? imagesx($user), $transform['crop']['h'] ?? imagesy($user));
+        imagecopyresampled(
+            $tmp,
+            $user,
+            0,
+            0,
+            $transform['crop']['x'] ?? 0,
+            $transform['crop']['y'] ?? 0,
+            $scaled_w,
+            $scaled_h,
+            $transform['crop']['w'] ?? imagesx($user),
+            $transform['crop']['h'] ?? imagesy($user)
+        );
         if (!empty($transform['rotation'])) {
             $tmp = imagerotate($tmp, -$transform['rotation'], 0);
         }
         $px = $bounds['x'] + ($transform['tx'] ?? 0);
         $py = $bounds['y'] + ($transform['ty'] ?? 0);
-        imagecopy($canvas, $tmp, $px, $py, 0, 0, imagesx($tmp), imagesy($tmp));
+        if ($mask_path) {
+            $layer = imagecreatetruecolor(imagesx($base), imagesy($base));
+            imagealphablending($layer, false);
+            imagesavealpha($layer, true);
+            $transparent = imagecolorallocatealpha($layer, 0, 0, 0, 127);
+            imagefill($layer, 0, 0, $transparent);
+            imagecopy($layer, $tmp, $px, $py, 0, 0, imagesx($tmp), imagesy($tmp));
+            $mask = imagecreatefromstring(@file_get_contents($mask_path));
+            if ($mask) {
+                if (imagesx($mask) !== imagesx($layer) || imagesy($mask) !== imagesy($layer)) {
+                    $resized_mask = imagecreatetruecolor(imagesx($layer), imagesy($layer));
+                    imagealphablending($resized_mask, false);
+                    imagesavealpha($resized_mask, true);
+                    imagecopyresampled(
+                        $resized_mask,
+                        $mask,
+                        0,
+                        0,
+                        0,
+                        0,
+                        imagesx($layer),
+                        imagesy($layer),
+                        imagesx($mask),
+                        imagesy($mask)
+                    );
+                    imagedestroy($mask);
+                    $mask = $resized_mask;
+                }
+                for ($x = 0; $x < imagesx($layer); $x++) {
+                    for ($y = 0; $y < imagesy($layer); $y++) {
+                        $layer_color = imagecolorat($layer, $x, $y);
+                        $mask_color  = imagecolorat($mask, $x, $y);
+                        $lrgb = imagecolorsforindex($layer, $layer_color);
+                        $mrgb = imagecolorsforindex($mask, $mask_color);
+                        $dest_opacity = 127 - $lrgb['alpha'];
+                        $mask_opacity = 127 - $mrgb['alpha'];
+                        $final_opacity = (int) ($dest_opacity * $mask_opacity / 127);
+                        $new_alpha = 127 - $final_opacity;
+                        $color = imagecolorallocatealpha($layer, $lrgb['red'], $lrgb['green'], $lrgb['blue'], $new_alpha);
+                        imagesetpixel($layer, $x, $y, $color);
+                    }
+                }
+                imagedestroy($mask);
+            }
+            imagecopy($canvas, $layer, 0, 0, 0, 0, imagesx($layer), imagesy($layer));
+            imagedestroy($layer);
+        } else {
+            imagecopy($canvas, $tmp, $px, $py, 0, 0, imagesx($tmp), imagesy($tmp));
+        }
         imagepng($canvas, $composite_out);
         $thumb = imagescale($canvas, 800);
         imagejpeg($thumb, $thumb_out, 90);


### PR DESCRIPTION
## Summary
- apply mask image with alpha blending in GD fallback renderer

## Testing
- `php -l includes/class-llp-renderer.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd17d9f08333811818451670745c