### PR TITLE
Add filter hooks for configurable settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 Development repository for the WooCommerce Laser Photo Mockup plugin. See `readme.txt` for WordPress.org style documentation.
 
 This branch merges previous work into main and includes initial plugin scaffolding.
+
+## Filters
+
+- `llp_output_dpi` – Adjust the output DPI used when rendering mockups or displaying variation settings.
+- `llp_allowed_mimes` – Filter the list of MIME types allowed during uploads.
+- `llp_storage_mode` – Override the storage mode (`private` or `public`) used for permission checks.

--- a/includes/class-llp-renderer.php
+++ b/includes/class-llp-renderer.php
@@ -23,7 +23,7 @@ class Renderer {
         $user_path    = $args['user_img'];
         $bounds       = $args['bounds'];
         $transform    = $args['transform'];
-        $output_dpi   = $args['output_dpi'] ?? 300;
+        $output_dpi   = (int) apply_filters('llp_output_dpi', $args['output_dpi'] ?? 300);
         $composite_out= $args['out_composite'];
         $thumb_out    = $args['out_thumb'];
 

--- a/includes/class-llp-rest.php
+++ b/includes/class-llp-rest.php
@@ -74,7 +74,8 @@ class REST {
             return new \WP_Error('invalid_nonce', __('Invalid nonce', 'llp'), ['status' => 403]);
         }
         $settings = Settings::instance();
-        if ('private' === $settings->get('storage')) {
+        $storage  = apply_filters('llp_storage_mode', $settings->get('storage'));
+        if ('private' === $storage) {
             if (!is_user_logged_in() || !current_user_can('upload_files')) {
                 return new \WP_Error('forbidden', __('Authentication required.', 'llp'), ['status' => 401]);
             }
@@ -178,7 +179,7 @@ class REST {
         $base_id   = (int) get_post_meta($variation_id, '_llp_base_image_id', true);
         $mask_id   = (int) get_post_meta($variation_id, '_llp_mask_image_id', true);
         $bounds    = json_decode((string) get_post_meta($variation_id, '_llp_bounds', true), true) ?: [];
-        $dpi       = (int) get_post_meta($variation_id, '_llp_output_dpi', true) ?: 300;
+        $dpi       = (int) apply_filters('llp_output_dpi', get_post_meta($variation_id, '_llp_output_dpi', true) ?: 300, $variation_id);
 
         if (!$base_id || empty($bounds)) {
             return new \WP_Error('missing_meta', __('Variation not configured', 'llp'), ['status' => 400]);

--- a/includes/class-llp-security.php
+++ b/includes/class-llp-security.php
@@ -26,7 +26,7 @@ class Security {
      */
     public function process_upload(array $file, string $dest, int $variation_id) {
         $settings = Settings::instance();
-        $allowed  = $settings->get('allowed_mimes');
+        $allowed  = apply_filters('llp_allowed_mimes', (array) $settings->get('allowed_mimes'));
         $max_size = (int) $settings->get('max_file_size');
         if ($file['error'] || $file['size'] > $max_size) {
             return new \WP_Error('upload_error', __('Upload failed.', 'llp'));

--- a/includes/class-llp-variation-fields.php
+++ b/includes/class-llp-variation-fields.php
@@ -49,6 +49,7 @@ class Variation_Fields {
         $aspect = get_post_meta($variation->ID, '_llp_aspect_ratio', true);
         $minres = json_decode((string) get_post_meta($variation->ID, '_llp_min_resolution', true), true) ?: [];
         $dpi    = get_post_meta($variation->ID, '_llp_output_dpi', true);
+        $dpi    = apply_filters('llp_output_dpi', $dpi, $variation->ID);
 
         echo '<div class="llp-variation-fields">';
         echo '<p class="form-field"><label for="llp_base_image_id_' . $loop . '">' . esc_html__('Base image ID', 'llp') . '</label>';


### PR DESCRIPTION
## Summary
- add `llp_output_dpi` filter to adjust rendering DPI
- add `llp_allowed_mimes` filter for upload validation
- add `llp_storage_mode` filter to modify storage mode
- document available filters

## Testing
- `php -l includes/class-llp-renderer.php`
- `php -l includes/class-llp-rest.php`
- `php -l includes/class-llp-security.php`
- `php -l includes/class-llp-variation-fields.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dd19876883339279b501e7f1d462