### PR TITLE
Use direct asset URLs in public storage mode

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -144,6 +144,7 @@
                 .then(r => r.json())
                 .then(res => {
                     if (res && res.thumb_url) {
+                        // thumb_url may be a direct asset link in public storage mode
                         preview.innerHTML = '<img src="' + res.thumb_url + '" alt="" />';
                         if (addBtn) { addBtn.disabled = false; }
                     }

--- a/includes/class-llp-frontend.php
+++ b/includes/class-llp-frontend.php
@@ -91,9 +91,9 @@ class Frontend {
             $cart_item_data['_llp_transform'] = wp_unslash($_POST['_llp_transform']);
             $asset_id = $cart_item_data['_llp_asset_id'];
             $sec = Security::instance();
-            $cart_item_data['_llp_original_url']  = $sec->sign_url($asset_id, 'original.png');
-            $cart_item_data['_llp_composite_url'] = $sec->sign_url($asset_id, 'composite.png');
-            $cart_item_data['_llp_thumb_url']     = $sec->sign_url($asset_id, 'thumb.jpg');
+            $cart_item_data['_llp_original_url']  = $sec->file_url($asset_id, 'original.png');
+            $cart_item_data['_llp_composite_url'] = $sec->file_url($asset_id, 'composite.png');
+            $cart_item_data['_llp_thumb_url']     = $sec->file_url($asset_id, 'thumb.jpg');
         }
         return $cart_item_data;
     }
@@ -103,7 +103,7 @@ class Frontend {
      */
     public function display_cart_item_data(array $item_data, array $cart_item): array {
         if (!empty($cart_item['_llp_asset_id'])) {
-            $thumb = Security::instance()->sign_url($cart_item['_llp_asset_id'], 'thumb.jpg');
+            $thumb = Security::instance()->file_url($cart_item['_llp_asset_id'], 'thumb.jpg');
             $item_data[] = [
                 'name'  => __('Preview', 'llp'),
                 'value' => '<img src="' . esc_url($thumb) . '" alt="" style="max-width:80px;" />',

--- a/includes/class-llp-order.php
+++ b/includes/class-llp-order.php
@@ -41,7 +41,7 @@ class Order {
         foreach ($order->get_items() as $item) {
             $asset_id = $item->get_meta('_llp_asset_id');
             if ($asset_id) {
-                $thumb = Security::instance()->sign_url($asset_id, 'thumb.jpg');
+                $thumb = Security::instance()->file_url($asset_id, 'thumb.jpg');
                 wc_get_template('emails/line-item-preview.php', ['thumb_url' => $thumb], '', LLP_DIR . 'templates/');
             }
         }
@@ -65,7 +65,7 @@ class Order {
         foreach ($order->get_items() as $item) {
             $asset_id = $item->get_meta('_llp_asset_id');
             if ($asset_id) {
-                $thumb = Security::instance()->sign_url($asset_id, 'thumb.jpg');
+                $thumb = Security::instance()->file_url($asset_id, 'thumb.jpg');
                 echo '<p><img src="' . esc_url($thumb) . '" style="max-width:100%;" /></p>';
             }
         }

--- a/includes/class-llp-rest.php
+++ b/includes/class-llp-rest.php
@@ -221,9 +221,9 @@ class REST {
         $sec = Security::instance();
         return rest_ensure_response([
             'asset_id'      => $asset_id,
-            'original_url'  => $sec->sign_url($asset_id, 'original.png'),
-            'composite_url' => $sec->sign_url($asset_id, 'composite.png'),
-            'thumb_url'     => $sec->sign_url($asset_id, 'thumb.jpg'),
+            'original_url'  => $sec->file_url($asset_id, 'original.png'),
+            'composite_url' => $sec->file_url($asset_id, 'composite.png'),
+            'thumb_url'     => $sec->file_url($asset_id, 'thumb.jpg'),
         ]);
     }
 

--- a/includes/class-llp-security.php
+++ b/includes/class-llp-security.php
@@ -79,6 +79,17 @@ class Security {
     }
 
     /**
+     * Generate a URL for downloading an asset respecting storage mode.
+     */
+    public function file_url(string $asset_id, string $file, int $expires = 0): string {
+        $settings = Settings::instance();
+        if ('public' === $settings->get('storage')) {
+            return Storage::instance()->asset_url($asset_id, $file);
+        }
+        return $this->sign_url($asset_id, $file, $expires);
+    }
+
+    /**
      * Generate a signed URL for downloading an asset.
      */
     public function sign_url(string $asset_id, string $file, int $expires = 0): string {


### PR DESCRIPTION
## Summary
- Add `Security::file_url` that returns signed or direct asset URLs based on storage mode
- Return direct asset links from REST finalize handler in public mode
- Update frontend, order code, and JS to consume direct URLs

## Testing
- `php -l includes/class-llp-security.php`
- `php -l includes/class-llp-rest.php`
- `php -l includes/class-llp-frontend.php`
- `php -l includes/class-llp-order.php`
- `node --check assets/js/frontend.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dd1a9384833380a0b196d782741e